### PR TITLE
feat: Add Model Competition & Benchmark commands (Issue #13)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,11 @@ C_SOURCES = $(SRC_DIR)/core/fabric.c \
             $(SRC_DIR)/sync/file_lock.c \
             $(SRC_DIR)/ui/statusbar.c \
             $(SRC_DIR)/ui/terminal.c \
-            $(SRC_DIR)/ui/hyperlink.c
+            $(SRC_DIR)/ui/hyperlink.c \
+            $(SRC_DIR)/compare/compare.c \
+            $(SRC_DIR)/compare/parallel.c \
+            $(SRC_DIR)/compare/render.c \
+            $(SRC_DIR)/compare/diff.c
 
 OBJC_SOURCES = $(SRC_DIR)/metal/gpu.m \
                $(SRC_DIR)/neural/mlx_embed.m \
@@ -167,6 +171,7 @@ dirs:
 	@mkdir -p $(OBJ_DIR)/providers
 	@mkdir -p $(OBJ_DIR)/router
 	@mkdir -p $(OBJ_DIR)/sync
+	@mkdir -p $(OBJ_DIR)/compare
 	@mkdir -p $(BIN_DIR)
 	@mkdir -p data
 

--- a/include/nous/compare.h
+++ b/include/nous/compare.h
@@ -1,0 +1,164 @@
+/**
+ * CONVERGIO MODEL COMPARISON & BENCHMARK
+ *
+ * Execute prompts across multiple models/providers in parallel
+ * and compare responses with metrics and diff analysis.
+ *
+ * Copyright 2025 - Roberto D'Angelo & AI Team
+ */
+
+#ifndef CONVERGIO_COMPARE_H
+#define CONVERGIO_COMPARE_H
+
+#include <stddef.h>
+#include <stdbool.h>
+
+// ============================================================================
+// COMPARISON RESULT
+// ============================================================================
+
+typedef struct {
+    char* model_id;              // Full model ID (e.g., "anthropic/claude-opus-4.5")
+    char* response;              // Full response text
+    double time_ms;              // Response time in milliseconds
+    size_t tokens_in;            // Input tokens consumed
+    size_t tokens_out;           // Output tokens generated
+    double cost;                 // Total cost in USD
+    bool success;                // Whether request succeeded
+    char* error;                 // Error message if failed (NULL if success)
+} CompareResult;
+
+// ============================================================================
+// COMPARISON MODES
+// ============================================================================
+
+typedef enum {
+    COMPARE_MODE_PARALLEL,       // Execute all models in parallel (default)
+    COMPARE_MODE_SEQUENTIAL      // Execute models one at a time
+} CompareMode;
+
+typedef struct {
+    CompareMode mode;
+    bool show_diff;              // Show text diff between responses
+    bool show_metrics;           // Show performance metrics
+    bool show_cost;              // Show cost breakdown
+    const char* output_format;   // "table" or "json"
+} CompareOptions;
+
+// ============================================================================
+// CORE COMPARISON FUNCTIONS
+// ============================================================================
+
+/**
+ * Run comparison across multiple models
+ * @param prompt The prompt to send to all models
+ * @param system System prompt (can be NULL)
+ * @param models Array of model IDs to compare
+ * @param model_count Number of models
+ * @param options Comparison options
+ * @param results Output array of results (caller must free with compare_results_free)
+ * @return 0 on success, -1 on error
+ */
+int compare_models(const char* prompt, const char* system,
+                   const char** models, size_t model_count,
+                   const CompareOptions* options,
+                   CompareResult** results);
+
+/**
+ * Run benchmark: measure performance of a single model
+ * @param prompt The prompt to benchmark
+ * @param system System prompt (can be NULL)
+ * @param model Model ID to benchmark
+ * @param iterations Number of iterations to run
+ * @param result Output result with average metrics (caller must free)
+ * @return 0 on success, -1 on error
+ */
+int benchmark_model(const char* prompt, const char* system,
+                    const char* model, size_t iterations,
+                    CompareResult* result);
+
+/**
+ * Free comparison results
+ * @param results Array of results to free
+ * @param count Number of results
+ */
+void compare_results_free(CompareResult* results, size_t count);
+
+// ============================================================================
+// RENDERING FUNCTIONS
+// ============================================================================
+
+/**
+ * Render comparison results as a formatted table
+ * @param results Array of comparison results
+ * @param count Number of results
+ * @param options Comparison options (controls what to display)
+ */
+void render_comparison_table(const CompareResult* results, size_t count,
+                              const CompareOptions* options);
+
+/**
+ * Render comparison results as JSON
+ * @param results Array of comparison results
+ * @param count Number of results
+ * @return JSON string (caller must free)
+ */
+char* render_comparison_json(const CompareResult* results, size_t count);
+
+/**
+ * Render performance metrics chart (ASCII bar chart)
+ * @param results Array of comparison results
+ * @param count Number of results
+ */
+void render_metrics_chart(const CompareResult* results, size_t count);
+
+// ============================================================================
+// DIFF FUNCTIONS
+// ============================================================================
+
+/**
+ * Generate line-by-line diff between two responses
+ * @param response1 First response
+ * @param response2 Second response
+ * @param label1 Label for first response (e.g., model name)
+ * @param label2 Label for second response
+ * @return Diff string in unified diff format (caller must free)
+ */
+char* generate_response_diff(const char* response1, const char* response2,
+                              const char* label1, const char* label2);
+
+/**
+ * Display diff between all pairs of responses
+ * @param results Array of comparison results
+ * @param count Number of results
+ */
+void display_all_diffs(const CompareResult* results, size_t count);
+
+// ============================================================================
+// PARALLEL EXECUTION
+// ============================================================================
+
+/**
+ * Execute multiple model requests in parallel using pthreads
+ * @param prompt The prompt to send
+ * @param system System prompt (can be NULL)
+ * @param models Array of model IDs
+ * @param model_count Number of models
+ * @param results Output array (caller must allocate with size model_count)
+ * @return 0 on success, -1 on error
+ */
+int parallel_execute(const char* prompt, const char* system,
+                     const char** models, size_t model_count,
+                     CompareResult* results);
+
+// ============================================================================
+// DEFAULT OPTIONS
+// ============================================================================
+
+/**
+ * Get default comparison options
+ * @return Default options structure
+ */
+CompareOptions compare_options_default(void);
+
+#endif // CONVERGIO_COMPARE_H

--- a/src/compare/compare.c
+++ b/src/compare/compare.c
@@ -1,0 +1,283 @@
+/**
+ * CONVERGIO MODEL COMPARISON - Core Implementation
+ *
+ * Main comparison logic and result management
+ */
+
+#include "nous/compare.h"
+#include "nous/provider.h"
+#include "nous/nous.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+// External parallel execution function
+extern int parallel_execute(const char* prompt, const char* system,
+                            const char** models, size_t model_count,
+                            CompareResult* results);
+
+// External rendering functions
+extern void render_comparison_table(const CompareResult* results, size_t count,
+                                    const CompareOptions* options);
+extern char* render_comparison_json(const CompareResult* results, size_t count);
+extern void display_all_diffs(const CompareResult* results, size_t count);
+
+// ============================================================================
+// DEFAULT OPTIONS
+// ============================================================================
+
+CompareOptions compare_options_default(void) {
+    CompareOptions opts = {
+        .mode = COMPARE_MODE_PARALLEL,
+        .show_diff = true,
+        .show_metrics = true,
+        .show_cost = true,
+        .output_format = "table"
+    };
+    return opts;
+}
+
+// ============================================================================
+// RESULT MANAGEMENT
+// ============================================================================
+
+void compare_results_free(CompareResult* results, size_t count) {
+    if (!results) return;
+
+    for (size_t i = 0; i < count; i++) {
+        free(results[i].model_id);
+        free(results[i].response);
+        free(results[i].error);
+    }
+    free(results);
+}
+
+// ============================================================================
+// SEQUENTIAL EXECUTION (FALLBACK)
+// ============================================================================
+
+static int sequential_execute(const char* prompt, const char* system,
+                              const char** models, size_t model_count,
+                              CompareResult* results) {
+    for (size_t i = 0; i < model_count; i++) {
+        CompareResult* res = &results[i];
+
+        // Initialize result
+        res->model_id = strdup(models[i]);
+        res->response = NULL;
+        res->error = NULL;
+        res->success = false;
+        res->time_ms = 0.0;
+        res->tokens_in = 0;
+        res->tokens_out = 0;
+        res->cost = 0.0;
+
+        // Get model config
+        const ModelConfig* model_cfg = model_get_config(models[i]);
+        if (!model_cfg) {
+            res->error = strdup("Model not found");
+            LOG_WARN(LOG_CAT_SYSTEM, "Model not found: %s", models[i]);
+            continue;
+        }
+
+        // Get provider
+        Provider* provider = provider_get(model_cfg->provider);
+        if (!provider || !provider->initialized) {
+            res->error = strdup("Provider not available");
+            LOG_WARN(LOG_CAT_SYSTEM, "Provider not available for model: %s", models[i]);
+            continue;
+        }
+
+        // Execute request
+        struct timespec start, end;
+        clock_gettime(CLOCK_MONOTONIC, &start);
+
+        TokenUsage usage = {0};
+        char* response = provider->chat(provider, model_cfg->id, system, prompt, &usage);
+
+        clock_gettime(CLOCK_MONOTONIC, &end);
+
+        double elapsed_ms = (end.tv_sec - start.tv_sec) * 1000.0 +
+                           (end.tv_nsec - start.tv_nsec) / 1000000.0;
+
+        if (response) {
+            res->success = true;
+            res->response = response;
+            res->time_ms = elapsed_ms;
+            res->tokens_in = usage.input_tokens;
+            res->tokens_out = usage.output_tokens;
+            res->cost = usage.estimated_cost;
+
+            LOG_INFO(LOG_CAT_SYSTEM, "Completed: %s (%.2fms, $%.4f)",
+                     models[i], elapsed_ms, usage.estimated_cost);
+        } else {
+            ProviderErrorInfo* err = provider->get_last_error(provider);
+            if (err && err->message) {
+                res->error = strdup(err->message);
+            } else {
+                res->error = strdup("Unknown error");
+            }
+            LOG_ERROR(LOG_CAT_SYSTEM, "Failed: %s - %s", models[i], res->error);
+        }
+    }
+
+    return 0;
+}
+
+// ============================================================================
+// MAIN COMPARISON FUNCTION
+// ============================================================================
+
+int compare_models(const char* prompt, const char* system,
+                   const char** models, size_t model_count,
+                   const CompareOptions* options,
+                   CompareResult** results) {
+    if (!prompt || !models || model_count == 0 || !results) {
+        LOG_ERROR(LOG_CAT_SYSTEM, "Invalid arguments to compare_models");
+        return -1;
+    }
+
+    // Use default options if not provided
+    CompareOptions opts = options ? *options : compare_options_default();
+
+    // Allocate results array
+    CompareResult* res = calloc(model_count, sizeof(CompareResult));
+    if (!res) {
+        LOG_ERROR(LOG_CAT_SYSTEM, "Failed to allocate results array");
+        return -1;
+    }
+
+    // Execute based on mode
+    int ret;
+    if (opts.mode == COMPARE_MODE_PARALLEL) {
+        LOG_INFO(LOG_CAT_SYSTEM, "Starting parallel execution across %zu models", model_count);
+        ret = parallel_execute(prompt, system, models, model_count, res);
+    } else {
+        LOG_INFO(LOG_CAT_SYSTEM, "Starting sequential execution across %zu models", model_count);
+        ret = sequential_execute(prompt, system, models, model_count, res);
+    }
+
+    if (ret != 0) {
+        compare_results_free(res, model_count);
+        return -1;
+    }
+
+    *results = res;
+
+    // Display results based on output format
+    if (strcmp(opts.output_format, "json") == 0) {
+        char* json = render_comparison_json(res, model_count);
+        if (json) {
+            printf("%s\n", json);
+            free(json);
+        }
+    } else {
+        render_comparison_table(res, model_count, &opts);
+
+        if (opts.show_diff) {
+            display_all_diffs(res, model_count);
+        }
+    }
+
+    return 0;
+}
+
+// ============================================================================
+// BENCHMARK FUNCTION
+// ============================================================================
+
+int benchmark_model(const char* prompt, const char* system,
+                    const char* model, size_t iterations,
+                    CompareResult* result) {
+    if (!prompt || !model || iterations == 0 || !result) {
+        LOG_ERROR(LOG_CAT_SYSTEM, "Invalid arguments to benchmark_model");
+        return -1;
+    }
+
+    // Initialize result
+    memset(result, 0, sizeof(CompareResult));
+    result->model_id = strdup(model);
+
+    // Get model config
+    const ModelConfig* model_cfg = model_get_config(model);
+    if (!model_cfg) {
+        result->error = strdup("Model not found");
+        return -1;
+    }
+
+    // Get provider
+    Provider* provider = provider_get(model_cfg->provider);
+    if (!provider || !provider->initialized) {
+        result->error = strdup("Provider not available");
+        return -1;
+    }
+
+    // Run iterations
+    double total_time_ms = 0.0;
+    size_t total_tokens_in = 0;
+    size_t total_tokens_out = 0;
+    double total_cost = 0.0;
+    size_t success_count = 0;
+
+    LOG_INFO(LOG_CAT_SYSTEM, "Starting benchmark: %zu iterations of %s", iterations, model);
+
+    for (size_t i = 0; i < iterations; i++) {
+        struct timespec start, end;
+        clock_gettime(CLOCK_MONOTONIC, &start);
+
+        TokenUsage usage = {0};
+        char* response = provider->chat(provider, model_cfg->id, system, prompt, &usage);
+
+        clock_gettime(CLOCK_MONOTONIC, &end);
+
+        double elapsed_ms = (end.tv_sec - start.tv_sec) * 1000.0 +
+                           (end.tv_nsec - start.tv_nsec) / 1000000.0;
+
+        if (response) {
+            success_count++;
+            total_time_ms += elapsed_ms;
+            total_tokens_in += usage.input_tokens;
+            total_tokens_out += usage.output_tokens;
+            total_cost += usage.estimated_cost;
+
+            // Keep the last successful response
+            if (result->response) {
+                free(result->response);
+            }
+            result->response = response;
+
+            LOG_DEBUG(LOG_CAT_SYSTEM, "Iteration %zu/%zu: %.2fms", i+1, iterations, elapsed_ms);
+        } else {
+            LOG_WARN(LOG_CAT_SYSTEM, "Iteration %zu/%zu failed", i+1, iterations);
+        }
+    }
+
+    if (success_count == 0) {
+        result->error = strdup("All iterations failed");
+        return -1;
+    }
+
+    // Calculate averages
+    result->success = true;
+    result->time_ms = total_time_ms / success_count;
+    result->tokens_in = total_tokens_in / success_count;
+    result->tokens_out = total_tokens_out / success_count;
+    result->cost = total_cost / success_count;
+
+    LOG_INFO(LOG_CAT_SYSTEM, "Benchmark complete: %s (avg %.2fms, $%.4f)",
+             model, result->time_ms, result->cost);
+
+    // Display benchmark results
+    printf("\n");
+    printf("=== Benchmark Results: %s ===\n", model);
+    printf("  Iterations:    %zu\n", iterations);
+    printf("  Success rate:  %zu/%zu (%.1f%%)\n", success_count, iterations,
+           (success_count * 100.0) / iterations);
+    printf("  Avg time:      %.2f ms\n", result->time_ms);
+    printf("  Avg tokens in: %zu\n", result->tokens_in);
+    printf("  Avg tokens out: %zu\n", result->tokens_out);
+    printf("  Avg cost:      $%.4f\n", result->cost);
+    printf("\n");
+
+    return 0;
+}

--- a/src/compare/diff.c
+++ b/src/compare/diff.c
@@ -1,0 +1,290 @@
+/**
+ * CONVERGIO MODEL COMPARISON - Diff Generation
+ *
+ * Line-by-line diff between model responses
+ */
+
+#include "nous/compare.h"
+#include "nous/nous.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// ============================================================================
+// LINE SPLITTING
+// ============================================================================
+
+typedef struct {
+    char** lines;
+    size_t count;
+} LineArray;
+
+static LineArray split_lines(const char* text) {
+    LineArray arr = {NULL, 0};
+    if (!text) return arr;
+
+    // Count lines
+    size_t count = 1;
+    for (const char* p = text; *p; p++) {
+        if (*p == '\n') count++;
+    }
+
+    // Allocate lines array
+    arr.lines = calloc(count, sizeof(char*));
+    if (!arr.lines) return arr;
+
+    // Split lines
+    const char* start = text;
+    size_t idx = 0;
+
+    for (const char* p = text; *p; p++) {
+        if (*p == '\n') {
+            size_t len = p - start;
+            arr.lines[idx] = malloc(len + 1);
+            if (arr.lines[idx]) {
+                memcpy(arr.lines[idx], start, len);
+                arr.lines[idx][len] = '\0';
+                idx++;
+            }
+            start = p + 1;
+        }
+    }
+
+    // Last line (if no trailing newline)
+    if (*start) {
+        arr.lines[idx] = strdup(start);
+        if (arr.lines[idx]) {
+            idx++;
+        }
+    }
+
+    arr.count = idx;
+    return arr;
+}
+
+static void free_line_array(LineArray* arr) {
+    if (!arr || !arr->lines) return;
+    for (size_t i = 0; i < arr->count; i++) {
+        free(arr->lines[i]);
+    }
+    free(arr->lines);
+    arr->lines = NULL;
+    arr->count = 0;
+}
+
+// ============================================================================
+// SIMPLE DIFF ALGORITHM (LCS-based approximation)
+// ============================================================================
+
+typedef enum {
+    DIFF_SAME,
+    DIFF_ADD,
+    DIFF_DELETE,
+    DIFF_CHANGE
+} DiffType;
+
+typedef struct {
+    DiffType type;
+    size_t line1;
+    size_t line2;
+    char* text;
+} DiffLine;
+
+static DiffLine* generate_diff_lines(const LineArray* arr1, const LineArray* arr2, size_t* out_count) {
+    // Simple line-by-line comparison (not optimal, but functional)
+    size_t max_lines = arr1->count + arr2->count;
+    DiffLine* diffs = calloc(max_lines, sizeof(DiffLine));
+    if (!diffs) return NULL;
+
+    size_t diff_count = 0;
+    size_t i1 = 0, i2 = 0;
+
+    while (i1 < arr1->count || i2 < arr2->count) {
+        if (i1 >= arr1->count) {
+            // Rest are additions
+            diffs[diff_count].type = DIFF_ADD;
+            diffs[diff_count].line2 = i2;
+            diffs[diff_count].text = strdup(arr2->lines[i2]);
+            diff_count++;
+            i2++;
+        } else if (i2 >= arr2->count) {
+            // Rest are deletions
+            diffs[diff_count].type = DIFF_DELETE;
+            diffs[diff_count].line1 = i1;
+            diffs[diff_count].text = strdup(arr1->lines[i1]);
+            diff_count++;
+            i1++;
+        } else if (strcmp(arr1->lines[i1], arr2->lines[i2]) == 0) {
+            // Lines are the same
+            diffs[diff_count].type = DIFF_SAME;
+            diffs[diff_count].line1 = i1;
+            diffs[diff_count].line2 = i2;
+            diffs[diff_count].text = strdup(arr1->lines[i1]);
+            diff_count++;
+            i1++;
+            i2++;
+        } else {
+            // Lines differ - check if it's a change or add/delete
+            // Simple heuristic: if next lines match, it's a change
+            if (i1 + 1 < arr1->count && i2 + 1 < arr2->count &&
+                strcmp(arr1->lines[i1 + 1], arr2->lines[i2 + 1]) == 0) {
+                // Change
+                diffs[diff_count].type = DIFF_DELETE;
+                diffs[diff_count].line1 = i1;
+                diffs[diff_count].text = strdup(arr1->lines[i1]);
+                diff_count++;
+
+                diffs[diff_count].type = DIFF_ADD;
+                diffs[diff_count].line2 = i2;
+                diffs[diff_count].text = strdup(arr2->lines[i2]);
+                diff_count++;
+
+                i1++;
+                i2++;
+            } else {
+                // Assume deletion for now
+                diffs[diff_count].type = DIFF_DELETE;
+                diffs[diff_count].line1 = i1;
+                diffs[diff_count].text = strdup(arr1->lines[i1]);
+                diff_count++;
+                i1++;
+            }
+        }
+    }
+
+    *out_count = diff_count;
+    return diffs;
+}
+
+static void free_diff_lines(DiffLine* diffs, size_t count) {
+    if (!diffs) return;
+    for (size_t i = 0; i < count; i++) {
+        free(diffs[i].text);
+    }
+    free(diffs);
+}
+
+// ============================================================================
+// DIFF RENDERING
+// ============================================================================
+
+char* generate_response_diff(const char* response1, const char* response2,
+                              const char* label1, const char* label2) {
+    if (!response1 || !response2) return NULL;
+
+    // Split into lines
+    LineArray arr1 = split_lines(response1);
+    LineArray arr2 = split_lines(response2);
+
+    if (!arr1.lines || !arr2.lines) {
+        free_line_array(&arr1);
+        free_line_array(&arr2);
+        return NULL;
+    }
+
+    // Generate diff
+    size_t diff_count = 0;
+    DiffLine* diffs = generate_diff_lines(&arr1, &arr2, &diff_count);
+
+    // Build output string
+    size_t output_size = 8192;
+    char* output = malloc(output_size);
+    if (!output) {
+        free_diff_lines(diffs, diff_count);
+        free_line_array(&arr1);
+        free_line_array(&arr2);
+        return NULL;
+    }
+
+    size_t pos = 0;
+    pos += snprintf(output + pos, output_size - pos, "--- %s\n", label1 ? label1 : "Response 1");
+    pos += snprintf(output + pos, output_size - pos, "+++ %s\n", label2 ? label2 : "Response 2");
+
+    for (size_t i = 0; i < diff_count && pos < output_size - 100; i++) {
+        switch (diffs[i].type) {
+            case DIFF_SAME:
+                pos += snprintf(output + pos, output_size - pos, "  %s\n",
+                               diffs[i].text ? diffs[i].text : "");
+                break;
+            case DIFF_DELETE:
+                pos += snprintf(output + pos, output_size - pos, "- %s\n",
+                               diffs[i].text ? diffs[i].text : "");
+                break;
+            case DIFF_ADD:
+                pos += snprintf(output + pos, output_size - pos, "+ %s\n",
+                               diffs[i].text ? diffs[i].text : "");
+                break;
+            case DIFF_CHANGE:
+                // Not used in current implementation
+                break;
+        }
+    }
+
+    free_diff_lines(diffs, diff_count);
+    free_line_array(&arr1);
+    free_line_array(&arr2);
+
+    return output;
+}
+
+// ============================================================================
+// DISPLAY ALL DIFFS
+// ============================================================================
+
+void display_all_diffs(const CompareResult* results, size_t count) {
+    if (!results || count < 2) return;
+
+    printf("\n");
+    printf("═══ RESPONSE DIFFS ═══\n");
+    printf("\n");
+
+    // Compare first successful result with all others
+    size_t base_idx = (size_t)-1;
+    for (size_t i = 0; i < count; i++) {
+        if (results[i].success && results[i].response) {
+            base_idx = i;
+            break;
+        }
+    }
+
+    if (base_idx == (size_t)-1) {
+        printf("No successful responses to compare.\n");
+        return;
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        if (i == base_idx) continue;
+        if (!results[i].success || !results[i].response) continue;
+
+        printf("\033[1mDiff: %s vs %s\033[0m\n", results[base_idx].model_id, results[i].model_id);
+        printf("────────────────────────────────────────────────────────────────\n");
+
+        char* diff = generate_response_diff(results[base_idx].response, results[i].response,
+                                           results[base_idx].model_id, results[i].model_id);
+        if (diff) {
+            // Colorize diff output
+            char* line = diff;
+            while (*line) {
+                if (*line == '-' && *(line + 1) != '-') {
+                    printf("\033[31m");  // Red for deletions
+                } else if (*line == '+' && *(line + 1) != '+') {
+                    printf("\033[32m");  // Green for additions
+                }
+
+                // Print until newline
+                char* end = strchr(line, '\n');
+                if (end) {
+                    printf("%.*s\033[0m\n", (int)(end - line), line);
+                    line = end + 1;
+                } else {
+                    printf("%s\033[0m\n", line);
+                    break;
+                }
+            }
+
+            free(diff);
+        }
+
+        printf("\n");
+    }
+}

--- a/src/compare/parallel.c
+++ b/src/compare/parallel.c
@@ -1,0 +1,166 @@
+/**
+ * CONVERGIO MODEL COMPARISON - Parallel Execution
+ *
+ * Execute multiple model requests in parallel using pthreads
+ */
+
+#include "nous/compare.h"
+#include "nous/provider.h"
+#include "nous/nous.h"
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <time.h>
+
+// ============================================================================
+// THREAD CONTEXT
+// ============================================================================
+
+typedef struct {
+    const char* prompt;
+    const char* system;
+    const char* model_id;
+    CompareResult* result;
+    pthread_t thread;
+} ThreadContext;
+
+// ============================================================================
+// THREAD WORKER FUNCTION
+// ============================================================================
+
+static void* execute_model_request(void* arg) {
+    ThreadContext* ctx = (ThreadContext*)arg;
+    CompareResult* res = ctx->result;
+
+    // Initialize result
+    res->model_id = strdup(ctx->model_id);
+    res->response = NULL;
+    res->error = NULL;
+    res->success = false;
+    res->time_ms = 0.0;
+    res->tokens_in = 0;
+    res->tokens_out = 0;
+    res->cost = 0.0;
+
+    // Get model config
+    const ModelConfig* model_cfg = model_get_config(ctx->model_id);
+    if (!model_cfg) {
+        res->error = strdup("Model not found");
+        LOG_WARN(LOG_CAT_SYSTEM, "Model not found: %s", ctx->model_id);
+        return NULL;
+    }
+
+    // Get provider
+    Provider* provider = provider_get(model_cfg->provider);
+    if (!provider || !provider->initialized) {
+        res->error = strdup("Provider not available");
+        LOG_WARN(LOG_CAT_SYSTEM, "Provider not available for model: %s", ctx->model_id);
+        return NULL;
+    }
+
+    // Execute request with timing
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+
+    TokenUsage usage = {0};
+    char* response = provider->chat(provider, model_cfg->id, ctx->system, ctx->prompt, &usage);
+
+    clock_gettime(CLOCK_MONOTONIC, &end);
+
+    // Calculate elapsed time
+    double elapsed_ms = (end.tv_sec - start.tv_sec) * 1000.0 +
+                       (end.tv_nsec - start.tv_nsec) / 1000000.0;
+
+    // Process result
+    if (response) {
+        res->success = true;
+        res->response = response;
+        res->time_ms = elapsed_ms;
+        res->tokens_in = usage.input_tokens;
+        res->tokens_out = usage.output_tokens;
+        res->cost = usage.estimated_cost;
+
+        LOG_INFO(LOG_CAT_SYSTEM, "Thread completed: %s (%.2fms, $%.4f)",
+                 ctx->model_id, elapsed_ms, usage.estimated_cost);
+    } else {
+        // Get error from provider
+        ProviderErrorInfo* err = provider->get_last_error(provider);
+        if (err && err->message) {
+            res->error = strdup(err->message);
+        } else {
+            res->error = strdup("Unknown error");
+        }
+        LOG_ERROR(LOG_CAT_SYSTEM, "Thread failed: %s - %s", ctx->model_id, res->error);
+    }
+
+    return NULL;
+}
+
+// ============================================================================
+// PARALLEL EXECUTION
+// ============================================================================
+
+int parallel_execute(const char* prompt, const char* system,
+                     const char** models, size_t model_count,
+                     CompareResult* results) {
+    if (!prompt || !models || model_count == 0 || !results) {
+        LOG_ERROR(LOG_CAT_SYSTEM, "Invalid arguments to parallel_execute");
+        return -1;
+    }
+
+    // Allocate thread contexts
+    ThreadContext* contexts = calloc(model_count, sizeof(ThreadContext));
+    if (!contexts) {
+        LOG_ERROR(LOG_CAT_SYSTEM, "Failed to allocate thread contexts");
+        return -1;
+    }
+
+    // Create threads
+    LOG_INFO(LOG_CAT_SYSTEM, "Spawning %zu threads for parallel execution", model_count);
+
+    for (size_t i = 0; i < model_count; i++) {
+        contexts[i].prompt = prompt;
+        contexts[i].system = system;
+        contexts[i].model_id = models[i];
+        contexts[i].result = &results[i];
+
+        int ret = pthread_create(&contexts[i].thread, NULL, execute_model_request, &contexts[i]);
+        if (ret != 0) {
+            LOG_ERROR(LOG_CAT_SYSTEM, "Failed to create thread for model: %s", models[i]);
+            // Mark as failed
+            results[i].model_id = strdup(models[i]);
+            results[i].error = strdup("Failed to create thread");
+            results[i].success = false;
+        } else {
+            LOG_DEBUG(LOG_CAT_SYSTEM, "Thread spawned for: %s", models[i]);
+        }
+    }
+
+    // Wait for all threads to complete
+    LOG_INFO(LOG_CAT_SYSTEM, "Waiting for all threads to complete...");
+
+    for (size_t i = 0; i < model_count; i++) {
+        if (contexts[i].thread) {
+            pthread_join(contexts[i].thread, NULL);
+            LOG_DEBUG(LOG_CAT_SYSTEM, "Thread joined: %s", models[i]);
+        }
+    }
+
+    free(contexts);
+
+    LOG_INFO(LOG_CAT_SYSTEM, "All threads completed");
+
+    // Count successes
+    size_t success_count = 0;
+    for (size_t i = 0; i < model_count; i++) {
+        if (results[i].success) {
+            success_count++;
+        }
+    }
+
+    LOG_INFO(LOG_CAT_SYSTEM, "Success rate: %zu/%zu (%.1f%%)",
+             success_count, model_count, (success_count * 100.0) / model_count);
+
+    return 0;
+}

--- a/src/compare/render.c
+++ b/src/compare/render.c
@@ -1,0 +1,240 @@
+/**
+ * CONVERGIO MODEL COMPARISON - Rendering
+ *
+ * Table and chart rendering for comparison results
+ */
+
+#include "nous/compare.h"
+#include "nous/nous.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// ============================================================================
+// UTILITY FUNCTIONS
+// ============================================================================
+
+static void print_separator(size_t width) {
+    for (size_t i = 0; i < width; i++) {
+        printf("─");
+    }
+    printf("\n");
+}
+
+static const char* truncate_string(const char* str, size_t max_len, char* buffer, size_t buf_size) {
+    if (!str) return "(null)";
+
+    size_t len = strlen(str);
+    if (len <= max_len) {
+        return str;
+    }
+
+    // Truncate and add ellipsis
+    size_t copy_len = (max_len - 3 < buf_size - 4) ? max_len - 3 : buf_size - 4;
+    strncpy(buffer, str, copy_len);
+    buffer[copy_len] = '\0';
+    strcat(buffer, "...");
+    return buffer;
+}
+
+// ============================================================================
+// TABLE RENDERING
+// ============================================================================
+
+void render_comparison_table(const CompareResult* results, size_t count,
+                              const CompareOptions* options) {
+    if (!results || count == 0) {
+        printf("No results to display.\n");
+        return;
+    }
+
+    printf("\n");
+    printf("╔═══════════════════════════════════════════════════════════════════════════╗\n");
+    printf("║                       MODEL COMPARISON RESULTS                            ║\n");
+    printf("╚═══════════════════════════════════════════════════════════════════════════╝\n");
+    printf("\n");
+
+    // Print summary table
+    printf("┌────────────────────────────────┬─────────┬──────────┬──────────┬──────────┐\n");
+    printf("│ Model                          │ Status  │ Time(ms) │ Tokens   │ Cost($)  │\n");
+    printf("├────────────────────────────────┼─────────┼──────────┼──────────┼──────────┤\n");
+
+    for (size_t i = 0; i < count; i++) {
+        const CompareResult* res = &results[i];
+
+        char model_buf[32];
+        const char* model_name = truncate_string(res->model_id, 28, model_buf, sizeof(model_buf));
+
+        if (res->success) {
+            printf("│ %-30s │ \033[32m✓\033[0m      │ %8.1f │ %8zu │ %8.4f │\n",
+                   model_name,
+                   res->time_ms,
+                   res->tokens_out,
+                   res->cost);
+        } else {
+            char err_buf[32];
+            const char* err_msg = truncate_string(res->error ? res->error : "Unknown", 28, err_buf, sizeof(err_buf));
+            printf("│ %-30s │ \033[31m✗\033[0m      │ %8s │ %8s │ %8s │\n",
+                   model_name, "-", "-", "-");
+            printf("│   Error: %-51s │\n", err_msg);
+        }
+    }
+
+    printf("└────────────────────────────────┴─────────┴──────────┴──────────┴──────────┘\n");
+
+    // Show detailed metrics if requested
+    if (options && options->show_metrics) {
+        printf("\n");
+        render_metrics_chart(results, count);
+    }
+
+    // Print responses
+    printf("\n");
+    printf("═══ RESPONSES ═══\n");
+    printf("\n");
+
+    for (size_t i = 0; i < count; i++) {
+        const CompareResult* res = &results[i];
+
+        if (res->success && res->response) {
+            printf("\033[1m► %s\033[0m\n", res->model_id);
+            print_separator(78);
+            printf("%s\n", res->response);
+            print_separator(78);
+            printf("\n");
+        }
+    }
+}
+
+// ============================================================================
+// METRICS CHART
+// ============================================================================
+
+void render_metrics_chart(const CompareResult* results, size_t count) {
+    if (!results || count == 0) return;
+
+    // Find max values for scaling
+    double max_time = 0.0;
+    double max_cost = 0.0;
+
+    for (size_t i = 0; i < count; i++) {
+        if (results[i].success) {
+            if (results[i].time_ms > max_time) max_time = results[i].time_ms;
+            if (results[i].cost > max_cost) max_cost = results[i].cost;
+        }
+    }
+
+    if (max_time == 0.0 && max_cost == 0.0) {
+        printf("No metrics to display.\n");
+        return;
+    }
+
+    printf("Performance Metrics:\n");
+    printf("\n");
+
+    // Response time chart
+    if (max_time > 0.0) {
+        printf("Response Time (ms):\n");
+        for (size_t i = 0; i < count; i++) {
+            if (results[i].success) {
+                char model_buf[24];
+                const char* model_name = truncate_string(results[i].model_id, 20, model_buf, sizeof(model_buf));
+                printf("  %-22s ", model_name);
+
+                int bar_width = (int)((results[i].time_ms / max_time) * 40);
+                for (int j = 0; j < bar_width; j++) {
+                    printf("█");
+                }
+                printf(" %.1f ms\n", results[i].time_ms);
+            }
+        }
+        printf("\n");
+    }
+
+    // Cost chart
+    if (max_cost > 0.0) {
+        printf("Cost ($):\n");
+        for (size_t i = 0; i < count; i++) {
+            if (results[i].success) {
+                char model_buf[24];
+                const char* model_name = truncate_string(results[i].model_id, 20, model_buf, sizeof(model_buf));
+                printf("  %-22s ", model_name);
+
+                int bar_width = (int)((results[i].cost / max_cost) * 40);
+                for (int j = 0; j < bar_width; j++) {
+                    printf("█");
+                }
+                printf(" $%.4f\n", results[i].cost);
+            }
+        }
+        printf("\n");
+    }
+}
+
+// ============================================================================
+// JSON RENDERING
+// ============================================================================
+
+static void json_escape_string(const char* str, char* out, size_t out_size) {
+    size_t j = 0;
+    for (size_t i = 0; str[i] && j < out_size - 2; i++) {
+        switch (str[i]) {
+            case '"':  out[j++] = '\\'; out[j++] = '"'; break;
+            case '\\': out[j++] = '\\'; out[j++] = '\\'; break;
+            case '\n': out[j++] = '\\'; out[j++] = 'n'; break;
+            case '\r': out[j++] = '\\'; out[j++] = 'r'; break;
+            case '\t': out[j++] = '\\'; out[j++] = 't'; break;
+            default:   out[j++] = str[i]; break;
+        }
+    }
+    out[j] = '\0';
+}
+
+char* render_comparison_json(const CompareResult* results, size_t count) {
+    if (!results || count == 0) return NULL;
+
+    // Estimate size (rough calculation)
+    size_t size = 1024 + (count * 4096);
+    char* json = malloc(size);
+    if (!json) return NULL;
+
+    size_t pos = 0;
+    pos += snprintf(json + pos, size - pos, "{\n  \"results\": [\n");
+
+    for (size_t i = 0; i < count; i++) {
+        const CompareResult* res = &results[i];
+
+        pos += snprintf(json + pos, size - pos, "    {\n");
+        pos += snprintf(json + pos, size - pos, "      \"model\": \"%s\",\n", res->model_id ? res->model_id : "");
+        pos += snprintf(json + pos, size - pos, "      \"success\": %s,\n", res->success ? "true" : "false");
+
+        if (res->success) {
+            pos += snprintf(json + pos, size - pos, "      \"time_ms\": %.2f,\n", res->time_ms);
+            pos += snprintf(json + pos, size - pos, "      \"tokens_in\": %zu,\n", res->tokens_in);
+            pos += snprintf(json + pos, size - pos, "      \"tokens_out\": %zu,\n", res->tokens_out);
+            pos += snprintf(json + pos, size - pos, "      \"cost\": %.4f,\n", res->cost);
+
+            if (res->response) {
+                char escaped[4096];
+                json_escape_string(res->response, escaped, sizeof(escaped));
+                pos += snprintf(json + pos, size - pos, "      \"response\": \"%s\"\n", escaped);
+            } else {
+                pos += snprintf(json + pos, size - pos, "      \"response\": null\n");
+            }
+        } else {
+            if (res->error) {
+                char escaped[512];
+                json_escape_string(res->error, escaped, sizeof(escaped));
+                pos += snprintf(json + pos, size - pos, "      \"error\": \"%s\"\n", escaped);
+            } else {
+                pos += snprintf(json + pos, size - pos, "      \"error\": \"Unknown error\"\n");
+            }
+        }
+
+        pos += snprintf(json + pos, size - pos, "    }%s\n", (i < count - 1) ? "," : "");
+    }
+
+    pos += snprintf(json + pos, size - pos, "  ]\n}\n");
+
+    return json;
+}

--- a/src/core/commands/commands.c
+++ b/src/core/commands/commands.c
@@ -401,6 +401,10 @@ int cmd_help(int argc, char** argv) {
     printf("  \033[33mauth\033[0m              Show authentication status\n");
     printf("  \033[33mlogout\033[0m            Logout and clear credentials\n");
 
+    printf("\n\033[36mModel Comparison:\033[0m\n");
+    printf("  \033[33mcompare\033[0m           Compare multiple models side-by-side\n");
+    printf("  \033[33mbenchmark\033[0m         Benchmark a model's performance\n");
+
     printf("\n\033[2mType 'help <command>' for detailed help on a specific command.\033[0m\n");
     printf("\033[2mOr simply talk to Ali, your Chief of Staff.\033[0m\n\n");
 
@@ -1175,8 +1179,7 @@ int cmd_compare(int argc, char** argv) {
     // Parse prompt
     const char* prompt = argv[1];
 
-    // Parse models
-    const char** models = (const char**)&argv[2];
+    // Count models
     size_t model_count = 0;
 
     // Count models and check for options


### PR DESCRIPTION
## Summary
- Implements `/compare` and `/benchmark` REPL commands
- Parallel multi-model comparison with pthreads
- Response time, token usage, and cost tracking
- Side-by-side table output with ASCII charts
- Line-by-line diff with color highlighting

## New Files
- `src/compare/compare.c` - Main comparison logic
- `src/compare/parallel.c` - Threaded execution
- `src/compare/render.c` - Table rendering
- `src/compare/diff.c` - Response diff
- `include/nous/compare.h` - Public API

## Test plan
- [x] Build compiles without errors or warnings
- [x] Help command shows Model Comparison section
- [ ] Manual testing of compare command

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)