### PR TITLE
feat: Session management with /recall command and quit compaction

### DIFF
--- a/.claude/agents/app-release-manager.md
+++ b/.claude/agents/app-release-manager.md
@@ -247,12 +247,15 @@ EF-10 NFRs + EF-11 DevEx + EF-12 Feedback
 
 #### Group E: AI Model Freshness (spawn together - FOR AI APPS)
 ```
-EF-13 ML/AI + EF-14 Model Freshness
+EF-13 ML/AI + EF-14 Model Freshness + EF-15 Apple Silicon Freshness
 - WebSearch for latest Anthropic models
 - WebSearch for latest OpenAI models
 - WebSearch for latest Google Gemini models
+- WebSearch for latest Apple Silicon specs (M4/M5)
 - Compare with models in codebase
+- Compare hardware.m with official Apple specs
 - Flag outdated/deprecated models
+- Flag outdated hardware specs
 ```
 
 ### Complete Parallel Execution Example
@@ -640,6 +643,72 @@ rg -i "feedback|report.*bug|issue" CONTRIBUTING.md README.md 2>/dev/null | head 
 
 **CRITICAL: Before every release, verify all AI models are current.**
 
+### EF-15: Apple Silicon Hardware Freshness (MANDATORY)
+
+**CRITICAL: Before every release, verify Apple Silicon specs are current.**
+
+#### Apple Silicon Freshness Check Process
+
+```bash
+# Use WebSearch to verify current Apple Silicon specs
+# Agent should search: "Apple M5 M4 specifications December 2025"
+```
+
+#### Required Checks
+
+1. **Check hardware.h for latest chip families**
+   - Verify M1, M2, M3, M4, M5 are all defined
+   - Check if new chip family announced (M6?)
+
+2. **Check hardware.m for accurate bandwidth specs**
+   - Search: "M4 Pro memory bandwidth GB/s 2025"
+   - Search: "M5 specifications neural engine 2025"
+   - Verify bandwidth values match official Apple specs
+
+3. **Check GPU core estimates**
+   - Search: "M4 Max GPU cores count"
+   - Search: "M5 GPU specifications"
+   - Update estimates in hardware.m
+
+#### Verification Script
+
+```bash
+echo "=== Apple Silicon Hardware Specs Check ==="
+
+# Check what chip families are defined
+echo "Chip families in hardware.h:"
+rg "CHIP_FAMILY_M[0-9]" include/nous/hardware.h
+
+# Check bandwidth values in hardware.m
+echo "Bandwidth values in hardware.m:"
+rg "bandwidth.*=" src/core/hardware.m | head -10
+
+# Check GPU core estimates
+echo "GPU core estimates:"
+rg "gpu_cores.*=" src/core/hardware.m | head -20
+
+# Flag if M5 is missing
+if ! grep -q "CHIP_FAMILY_M5" include/nous/hardware.h; then
+  echo "❌ M5 chip family NOT defined - needs update!"
+else
+  echo "✅ M5 chip family defined"
+fi
+```
+
+#### Update Procedure
+
+If outdated specs are found:
+
+1. **Research** - Use WebSearch to find current Apple Silicon specs
+2. **Update hardware.h** - Add new chip families to enum
+3. **Update hardware.m** - Update CHIP_PROFILES array with accurate:
+   - Bandwidth values (GB/s)
+   - Neural Engine core counts
+   - GPU core estimates
+4. **Update convergio_chip_family_name()** - Add new chip names
+5. **Test** - Verify `convergio version` shows correct detection
+6. **Changelog** - Document hardware updates
+
 #### Model Freshness Check Process
 
 ```bash
@@ -953,6 +1022,7 @@ Date: {DATE}
 ✅/❌ EF-12 Engineering Feedback: {status}
 ✅/⬜ EF-13 ML/AI (if applicable): {status or N/A}
 ✅/❌ EF-14 AI Model Freshness: {status}
+✅/❌ EF-15 Apple Silicon Freshness: {status}
 
 ### Quality Gates Status
 ✅/❌ Code Quality: {status}

--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ $(UNIT_TEST): $(UNIT_SOURCES) $(UNIT_OBJECTS)
 # Compaction test target - tests context compaction module
 COMPACTION_TEST = $(BIN_DIR)/compaction_test
 COMPACTION_SOURCES = tests/test_compaction.c
-# Only need compaction.o and its minimal dependencies for this test
+# Only need compaction.o - test file provides stubs for persistence functions
 COMPACTION_OBJECTS = $(OBJ_DIR)/context/compaction.o
 
 compaction_test: dirs $(OBJ_DIR)/context/compaction.o $(COMPACTION_TEST)

--- a/include/nous/hardware.h
+++ b/include/nous/hardware.h
@@ -2,7 +2,7 @@
  * CONVERGIO HARDWARE DETECTION
  *
  * Auto-detection and optimization for Apple Silicon chips
- * Supports M1, M2, M3, M4 and all variants (Pro, Max, Ultra)
+ * Supports M1, M2, M3, M4, M5 and all variants (Pro, Max, Ultra)
  *
  * Copyright 2025 - Roberto D'Angelo & AI Team
  */
@@ -29,7 +29,8 @@ typedef enum {
     CHIP_FAMILY_M1 = 1,
     CHIP_FAMILY_M2 = 2,
     CHIP_FAMILY_M3 = 3,
-    CHIP_FAMILY_M4 = 4
+    CHIP_FAMILY_M4 = 4,
+    CHIP_FAMILY_M5 = 5   // Nov 2025 - Neural Accelerators in GPU
 } ChipFamily;
 
 // ============================================================================

--- a/include/nous/orchestrator.h
+++ b/include/nous/orchestrator.h
@@ -272,6 +272,10 @@ void orchestrator_set_user(const char* name, const char* preferences);
 // Status
 char* orchestrator_status(void);
 
+// Session management
+const char* orchestrator_get_session_id(void);
+int orchestrator_compact_session(void (*progress_callback)(int percent, const char* msg));
+
 // ============================================================================
 // PERSISTENCE API
 // ============================================================================
@@ -298,6 +302,29 @@ char** persistence_get_important_memories(size_t limit, size_t* out_count);
 
 char* persistence_create_session(const char* user_name);
 int persistence_end_session(const char* session_id, double total_cost, int total_messages);
+
+// Session summaries for /recall command
+typedef struct {
+    char* session_id;
+    char* started_at;
+    char* summary;
+    int message_count;
+} SessionSummary;
+
+typedef struct {
+    SessionSummary* items;
+    size_t count;
+    size_t capacity;
+} SessionSummaryList;
+
+SessionSummaryList* persistence_get_session_summaries(void);
+void persistence_free_session_summaries(SessionSummaryList* list);
+int persistence_delete_session(const char* session_id);
+int persistence_clear_all_summaries(void);
+int64_t persistence_get_cutoff_message_id(const char* session_id, int keep_recent);
+int persistence_get_message_id_range(const char* session_id, int64_t* out_first, int64_t* out_last);
+char* persistence_load_messages_range(const char* session_id, int64_t from_id, int64_t to_id, size_t* out_count);
+int persistence_get_session_message_count(const char* session_id);
 
 // ============================================================================
 // MESSAGE BUS API

--- a/src/core/repl.c
+++ b/src/core/repl.c
@@ -185,11 +185,32 @@ void repl_print_separator(void) {
     printf("\n" ANSI_DIM "────────────────────────────────────────────────────────────────" ANSI_RESET "\n\n");
 }
 
+// Dynamic spinner verbs - changes every few seconds for visual interest
+static const char* SPINNER_VERBS[] = {
+    "Thinking",
+    "Pondering",
+    "Analyzing",
+    "Reasoning",
+    "Synthesizing",
+    "Processing",
+    "Contemplating",
+    "Evaluating",
+    "Considering",
+    "Reflecting",
+    "Deliberating",
+    "Exploring",
+};
+#define SPINNER_VERB_COUNT 12
+
 // Spinner thread function - polls for ESC key to cancel
 static void* spinner_func(void* arg) {
     (void)arg;
+
+    // Animated spinner frames (braille dots pattern)
     const char* frames[] = {"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"};
     int frame = 0;
+    int verb_index = 0;
+    int ticks = 0;
 
     // Save terminal settings and enable raw mode for ESC detection
     struct termios raw;
@@ -212,9 +233,18 @@ static void* spinner_func(void* arg) {
             }
         }
 
-        printf(ANSI_CURSOR_START ANSI_DIM "%s thinking... " ANSI_RESET "(ESC to cancel)  ", frames[frame]);
+        // Change verb every ~3 seconds (37 ticks * 80ms = ~3s)
+        if (ticks > 0 && ticks % 37 == 0) {
+            verb_index = (verb_index + 1) % SPINNER_VERB_COUNT;
+        }
+
+        // Colored spinner with dynamic verb (using standard ANSI colors for compatibility)
+        printf(ANSI_CURSOR_START ANSI_CYAN "%s" ANSI_RESET " " ANSI_DIM "%s..." ANSI_RESET "  (ESC to cancel)  ",
+               frames[frame], SPINNER_VERBS[verb_index]);
         fflush(stdout);
+
         frame = (frame + 1) % 10;
+        ticks++;
         usleep(80000);  // 80ms
     }
 

--- a/tests/test_compaction.c
+++ b/tests/test_compaction.c
@@ -117,6 +117,15 @@ char* persistence_load_conversation_context(const char* session_id, size_t max_m
     return strdup("");
 }
 
+int64_t persistence_get_cutoff_message_id(const char* session_id, int keep_recent) {
+    (void)session_id; (void)keep_recent;
+    // Return a cutoff that leaves 'keep_recent' messages at the end
+    if (g_mock_last_msg_id - g_mock_first_msg_id < keep_recent) {
+        return -1;  // Not enough messages
+    }
+    return g_mock_last_msg_id - keep_recent;
+}
+
 // Mock provider functions
 static bool g_provider_available = true;
 static char* g_mock_llm_response = NULL;


### PR DESCRIPTION
## Summary
- **Session compaction on quit**: Automatically summarizes conversation before exit with progress bar
- **`/recall` command**: View past session summaries, with `clear` and `delete <id>` subcommands
- **Performance fix**: Reduced message loading from 100 to 10 per request
- **Bug fixes**: Non-consecutive message ID handling, M5 chip specs (verified vs projected), ANSI color compatibility
- **UX improvement**: Dynamic spinner with rotating verbs during thinking
- **Release manager**: Added EF-15 Apple Silicon Hardware Freshness check

## Changes

### Session Management
- `src/orchestrator/orchestrator.c`: Added `orchestrator_compact_session()`, reduced message loading
- `src/memory/persistence.c`: New session summary functions
- `src/core/commands/commands.c`: Added `/recall` command and quit progress bar
- `src/context/compaction.c`: Fixed cutoff ID calculation for non-consecutive message IDs
- `include/nous/orchestrator.h`: Added new function declarations

### UX Improvements
- `src/core/repl.c`: Dynamic spinner with rotating verbs during thinking
- Fixed 256-color ANSI codes to standard colors for terminal compatibility

### Hardware Detection
- `src/core/hardware.m`: Corrected M5 specs (base verified Oct 2025, Pro/Max/Ultra projected 2026)
- `include/nous/hardware.h`: Updated chip family definitions

### Release Process
- `.claude/agents/app-release-manager.md`: Added EF-15 Apple Silicon Hardware Freshness mandatory check
- `Makefile`: Added context directory to dirs target
- `tests/test_compaction.c`: Updated compaction tests
- `docs/CONTEXT_COMPACTION.md`: Updated documentation

## Test plan
- [ ] Run `convergio` and have a conversation
- [ ] Type `quit` - verify progress bar shows during compaction
- [ ] Start new session and run `/recall` - verify session summary appears
- [ ] Run `/recall delete <id>` to delete a specific session
- [ ] Run `/recall clear` to clear all summaries
- [ ] Verify spinner shows rotating verbs during thinking
- [ ] Run `/hw` and verify M5 specs show correctly

🤖 Generated with Claude Code