### PR TITLE
feat: Add recall load command and improve UX

### DIFF
--- a/include/nous/orchestrator.h
+++ b/include/nous/orchestrator.h
@@ -325,6 +325,7 @@ int64_t persistence_get_cutoff_message_id(const char* session_id, int keep_recen
 int persistence_get_message_id_range(const char* session_id, int64_t* out_first, int64_t* out_last);
 char* persistence_load_messages_range(const char* session_id, int64_t from_id, int64_t to_id, size_t* out_count);
 int persistence_get_session_message_count(const char* session_id);
+char* persistence_load_latest_checkpoint(const char* session_id);
 
 // ============================================================================
 // MESSAGE BUS API


### PR DESCRIPTION
## Summary
- Add `recall load <n>` command to load past session context
- Add recall to main help display under SYSTEM section
- Improve recall UX with numeric indices instead of UUIDs

## Changes
- `src/core/commands/commands.c`: 
  - Add `recall load <n>` to inject past context into current session
  - Use numeric indices [1], [2] for all recall commands
  - Show longer summaries (300 chars) with word wrapping
  - Add recall to SYSTEM section in help
  - Update detailed help with new syntax
- `include/nous/orchestrator.h`: Add `persistence_load_latest_checkpoint` declaration

## Test plan
- [ ] Run `help` - verify recall appears in SYSTEM section
- [ ] Run `recall` - verify sessions show with readable summaries
- [ ] Run `recall load 1` - verify context is loaded and shown
- [ ] Run `recall delete 1` - verify can delete by number
- [ ] Run `help recall` - verify updated help shows all commands

🤖 Generated with Claude Code