### PR TITLE
fix: centralize curl_global_init in main.c for thread safety

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -31,6 +31,7 @@
 #include <sys/ioctl.h>
 #include <readline/readline.h>
 #include <readline/history.h>
+#include <curl/curl.h>  // For curl_global_init/cleanup - must be called once before any threads
 
 
 // ============================================================================
@@ -299,6 +300,10 @@ int main(int argc, char** argv) {
 
     // Setup signal handling
     signals_init();
+
+    // Initialize libcurl globally - MUST be called once before any threads
+    // See: https://curl.se/libcurl/c/curl_global_init.html
+    curl_global_init(CURL_GLOBAL_DEFAULT);
 
     print_banner();
 
@@ -680,6 +685,9 @@ int main(int argc, char** argv) {
     nous_shutdown();
     auth_shutdown();
     convergio_config_shutdown();
+
+    // Cleanup libcurl globally - must be last curl operation
+    curl_global_cleanup();
 
     printf("Goodbye.\n");
     return 0;

--- a/src/mcp/mcp_client.c
+++ b/src/mcp/mcp_client.c
@@ -98,9 +98,7 @@ int mcp_init(void) {
 
     pthread_mutex_init(&g_mcp.lock, NULL);
 
-    // Initialize curl for HTTP transport
-    curl_global_init(CURL_GLOBAL_DEFAULT);
-
+    // Note: curl_global_init is called once in main.c at startup
     g_mcp.initialized = true;
 
     // Try to load default config

--- a/src/neural/claude.c
+++ b/src/neural/claude.c
@@ -319,9 +319,7 @@ int nous_claude_init(void) {
     }
     free(auth_header);
 
-    // Initialize libcurl globally (thread-safe)
-    curl_global_init(CURL_GLOBAL_DEFAULT);
-
+    // Note: curl_global_init is called once in main.c at startup
     g_initialized = true;
     return 0;
 }
@@ -329,8 +327,7 @@ int nous_claude_init(void) {
 void nous_claude_shutdown(void) {
     if (!g_initialized) return;
 
-    curl_global_cleanup();
-
+    // Note: curl_global_cleanup is called once in main.c at shutdown
     // Note: auth_shutdown() is called separately in main.c
 
     g_initialized = false;

--- a/src/providers/anthropic.c
+++ b/src/providers/anthropic.c
@@ -444,9 +444,7 @@ static ProviderError anthropic_init(Provider* self) {
         }
     }
 
-    // Initialize curl
-    curl_global_init(CURL_GLOBAL_DEFAULT);
-
+    // Note: curl_global_init is called once in main.c at startup
     data->initialized = true;
     self->initialized = true;
 

--- a/src/providers/gemini.c
+++ b/src/providers/gemini.c
@@ -270,8 +270,7 @@ static ProviderError gemini_init(Provider* self) {
         return PROVIDER_ERR_AUTH;
     }
 
-    curl_global_init(CURL_GLOBAL_DEFAULT);
-
+    // Note: curl_global_init is called once in main.c at startup
     data->initialized = true;
     self->initialized = true;
 

--- a/src/providers/ollama.c
+++ b/src/providers/ollama.c
@@ -349,8 +349,7 @@ static ProviderError ollama_init(Provider* self) {
         return PROVIDER_ERR_NETWORK;
     }
 
-    curl_global_init(CURL_GLOBAL_DEFAULT);
-
+    // Note: curl_global_init is called once in main.c at startup
     data->initialized = true;
     self->initialized = true;
 

--- a/src/providers/openai.c
+++ b/src/providers/openai.c
@@ -277,8 +277,7 @@ static ProviderError openai_init(Provider* self) {
         return PROVIDER_ERR_AUTH;
     }
 
-    curl_global_init(CURL_GLOBAL_DEFAULT);
-
+    // Note: curl_global_init is called once in main.c at startup
     data->initialized = true;
     self->initialized = true;
 

--- a/src/providers/openrouter.c
+++ b/src/providers/openrouter.c
@@ -251,8 +251,7 @@ static ProviderError openrouter_init(Provider* self) {
         return PROVIDER_ERR_AUTH;
     }
 
-    curl_global_init(CURL_GLOBAL_DEFAULT);
-
+    // Note: curl_global_init is called once in main.c at startup
     data->initialized = true;
     self->initialized = true;
 


### PR DESCRIPTION
## Summary
Centralizes curl_global_init() in main.c for thread safety.

## Problem
curl_global_init() was called 7 times in different provider/client files.
libcurl docs state it is NOT thread-safe and must be called once before any threads.

## Changes
- Added curl_global_init() to main.c at startup
- Added curl_global_cleanup() to main.c at shutdown
- Removed redundant calls from 7 files

## References
- https://curl.se/libcurl/c/curl_global_init.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)