### PR TITLE
fix: add response size limits to prevent OOM attacks

### DIFF
--- a/src/core/updater.c
+++ b/src/core/updater.c
@@ -72,9 +72,17 @@ typedef struct {
     size_t size;
 } ResponseBuffer;
 
+// Maximum response size for GitHub API (256KB should be plenty for release JSON)
+#define MAX_UPDATER_RESPONSE_SIZE (256 * 1024)
+
 static size_t write_callback(void* contents, size_t size, size_t nmemb, void* userp) {
     size_t realsize = size * nmemb;
     ResponseBuffer* buf = (ResponseBuffer*)userp;
+
+    // Check response size limit to prevent OOM
+    if (buf->size + realsize > MAX_UPDATER_RESPONSE_SIZE) {
+        return 0;  // Abort transfer
+    }
 
     char* ptr = realloc(buf->data, buf->size + realsize + 1);
     if (!ptr) {


### PR DESCRIPTION
## Summary
Adds MAX_RESPONSE_SIZE checks to curl callbacks to prevent OOM.

## Problem
mcp_client.c, updater.c, and oauth.m had unbounded realloc in curl callbacks.
A malicious server could cause OOM by sending gigabytes of data.

## Solution
- mcp_client.c: 1MB limit (MCP resources can be large)
- updater.c: 256KB limit (GitHub API JSON)
- oauth.m: 64KB limit (OAuth tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)