### PR TITLE
fix: suppress banner in quiet mode, enable E2E tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,6 @@ jobs:
         run: brew install coreutils
 
       - name: Run E2E tests
-        continue-on-error: true  # TODO: Fix quiet mode banner display
         run: |
           chmod +x tests/e2e_test.sh
           ./tests/e2e_test.sh 2>&1
@@ -227,15 +226,12 @@ jobs:
     steps:
       - name: Check all jobs passed
         run: |
-          # Required jobs: lint, build, sanitizers
-          # E2E tests are continue-on-error (TODO: fix quiet mode banner)
+          # All jobs are now required (E2E quiet mode banner fixed)
           if [ "${{ needs.lint-and-analysis.result }}" != "success" ] || \
              [ "${{ needs.build.result }}" != "success" ] || \
-             [ "${{ needs.sanitizer-tests.result }}" != "success" ]; then
+             [ "${{ needs.sanitizer-tests.result }}" != "success" ] || \
+             [ "${{ needs.e2e-tests.result }}" != "success" ]; then
             echo "::error::One or more required jobs failed"
             exit 1
-          fi
-          if [ "${{ needs.e2e-tests.result }}" != "success" ]; then
-            echo "::warning::E2E tests failed (non-blocking)"
           fi
           echo "All CI checks passed!"

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -305,10 +305,14 @@ int main(int argc, char** argv) {
     // See: https://curl.se/libcurl/c/curl_global_init.html
     curl_global_init(CURL_GLOBAL_DEFAULT);
 
-    print_banner();
+    // Only print banner if not in quiet mode (-q sets LOG_LEVEL_ERROR)
+    bool quiet_mode = (g_log_level == LOG_LEVEL_ERROR);
+    if (!quiet_mode) {
+        print_banner();
+    }
 
-    // Show debug mode if enabled
-    if (g_log_level != LOG_LEVEL_NONE) {
+    // Show debug mode if enabled (but not in quiet mode)
+    if (!quiet_mode && g_log_level != LOG_LEVEL_NONE) {
         printf("  \033[33m⚡ Debug mode: %s\033[0m\n\n", nous_log_level_name(g_log_level));
     }
 


### PR DESCRIPTION
## Summary
Fixes E2E test failures caused by banner display in quiet mode.

## Changes
- Banner is now suppressed when `-q` flag is used
- Debug mode indicator also suppressed in quiet mode
- E2E tests are now **required** in CI (no longer continue-on-error)

## Test
```bash
# Before: banner showed in quiet mode
# After: no banner in quiet mode
echo "quit" | ./build/bin/convergio -q
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)