### PR TITLE
feat(output-service): Centralized service for structured document output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ C_SOURCES = $(SRC_DIR)/core/fabric.c \
             $(SRC_DIR)/memory/semantic_persistence.c \
             $(SRC_DIR)/context/compaction.c \
             $(SRC_DIR)/tools/tools.c \
+            $(SRC_DIR)/tools/output_service.c \
             $(SRC_DIR)/providers/provider.c \
             $(SRC_DIR)/providers/common.c \
             $(SRC_DIR)/providers/anthropic.c \
@@ -484,13 +485,26 @@ $(PLAN_DB_TEST): $(PLAN_DB_SOURCES) $(PLAN_DB_OBJECTS)
 	@echo "Compiling plan database tests..."
 	@$(CC) $(CFLAGS) $(LDFLAGS) -o $(PLAN_DB_TEST) $(PLAN_DB_SOURCES) $(PLAN_DB_OBJECTS) -lsqlite3 -lpthread
 
+# Output service test target - tests centralized document generation
+OUTPUT_SERVICE_TEST = $(BIN_DIR)/output_service_test
+OUTPUT_SERVICE_SOURCES = tests/test_output_service.c
+OUTPUT_SERVICE_OBJECTS = $(OBJ_DIR)/tools/output_service.o $(OBJ_DIR)/ui/hyperlink.o
+
+output_service_test: dirs $(OUTPUT_SERVICE_OBJECTS) $(OUTPUT_SERVICE_TEST)
+	@echo "Running output service tests..."
+	@$(OUTPUT_SERVICE_TEST)
+
+$(OUTPUT_SERVICE_TEST): $(OUTPUT_SERVICE_SOURCES) $(OUTPUT_SERVICE_OBJECTS)
+	@echo "Compiling output service tests..."
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $(OUTPUT_SERVICE_TEST) $(OUTPUT_SERVICE_SOURCES) $(OUTPUT_SERVICE_OBJECTS)
+
 # Check help documentation coverage
 check-docs:
 	@echo "Checking help documentation coverage..."
 	@./scripts/check_help_docs.sh
 
 # Run all tests
-test: fuzz_test unit_test anna_test compaction_test plan_db_test check-docs
+test: fuzz_test unit_test anna_test compaction_test plan_db_test output_service_test check-docs
 	@echo "All tests completed!"
 
 # Help
@@ -510,6 +524,7 @@ help:
 	@echo "  unit_test  - Build and run unit tests"
 	@echo "  anna_test  - Build and run Anna Executive Assistant tests"
 	@echo "  plan_db_test - Build and run plan database tests"
+	@echo "  output_service_test - Build and run output service tests"
 	@echo "  check-docs - Verify all REPL commands are documented"
 	@echo "  hwinfo     - Show Apple Silicon hardware info"
 	@echo "  version    - Show version"
@@ -518,4 +533,4 @@ help:
 	@echo "Variables:"
 	@echo "  DEBUG=1   - Enable debug build"
 
-.PHONY: all dirs metal run clean debug install uninstall hwinfo help fuzz_test unit_test anna_test plan_db_test check-docs test version dist release
+.PHONY: all dirs metal run clean debug install uninstall hwinfo help fuzz_test unit_test anna_test plan_db_test output_service_test check-docs test version dist release

--- a/docs/adr/012-output-service.md
+++ b/docs/adr/012-output-service.md
@@ -1,0 +1,246 @@
+# ADR-012: Centralized Output Service
+
+**Date**: 2025-12-16
+**Status**: Implemented
+**Author**: AI Team
+
+## Context
+
+Convergio's multi-agent system generates various outputs: analysis reports, architecture diagrams, status updates, etc. Currently:
+
+1. **No standard format** - Each agent outputs differently
+2. **Terminal-only** - Rich content lost when session ends
+3. **No diagrams** - Mermaid/charts not leveraged
+4. **No links** - Users must copy/paste paths
+
+Inspired by Anthropic's `claude-quickstarts/financial-data-analyst` pattern of Claude-driven visualization, we need a unified output service.
+
+## Decision
+
+Implement a **centralized output service** that provides:
+
+### Core Features
+
+1. **Document generation** - Markdown with metadata
+2. **Mermaid integration** - Flowcharts, sequence, gantt, pie, mindmap
+3. **Table generation** - Formatted markdown tables
+4. **Terminal links** - OSC8 hyperlinks (clickable paths)
+5. **File management** - Organization, cleanup, listing
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Output Service                        │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────────┐ │
+│  │   Document  │  │   Mermaid   │  │     Table       │ │
+│  │  Generator  │  │   Helpers   │  │    Builder      │ │
+│  └─────────────┘  └─────────────┘  └─────────────────┘ │
+│          │               │                │             │
+│          └───────────────┼────────────────┘             │
+│                          ▼                              │
+│              ┌──────────────────────┐                   │
+│              │    File Manager      │                   │
+│              │  - Path generation   │                   │
+│              │  - OSC8 links        │                   │
+│              │  - Cleanup policy    │                   │
+│              └──────────────────────┘                   │
+│                          │                              │
+│                          ▼                              │
+│              ~/.convergio/outputs/                      │
+│                 └── 2025-12-16/                         │
+│                     └── project-name/                   │
+│                         └── report-abc123.md            │
+└─────────────────────────────────────────────────────────┘
+```
+
+### API Design
+
+```c
+// Create document
+OutputRequest req = {
+    .title = "Analysis Report",
+    .content = markdown_content,
+    .agent_name = "baccio",
+    .project_context = "MyProject",
+    .format = OUTPUT_FORMAT_MARKDOWN,
+    .include_timestamp = true
+};
+OutputResult result;
+output_create(&req, &result);
+// result.filepath = ~/.convergio/outputs/2025-12-16/myproject/analysis-report-abc123.md
+// result.terminal_link = OSC8 clickable link
+```
+
+### Mermaid Helpers
+
+| Function | Output |
+|----------|--------|
+| `output_mermaid_flowchart()` | flowchart LR/TD |
+| `output_mermaid_sequence()` | sequenceDiagram |
+| `output_mermaid_gantt()` | gantt chart |
+| `output_mermaid_pie()` | pie chart |
+| `output_mermaid_mindmap()` | mindmap |
+
+### Terminal Integration
+
+Uses existing `hyperlink.h` for OSC8 support:
+
+```c
+// Terminal output
+📄 Analysis Report
+   ^--- clickable link (in iTerm2, Warp, Kitty, etc.)
+```
+
+## Alternatives Considered
+
+### Option A: Direct file writes per agent
+
+**Pros:**
+- Simple, no coordination needed
+
+**Cons:**
+- Inconsistent formats
+- No organization
+- No link generation
+
+**Decision:** Rejected - We want consistency across agents.
+
+### Option B: HTML generation
+
+**Pros:**
+- Rich formatting
+- Browser viewable
+
+**Cons:**
+- More complex
+- Markdown more universal
+- Warp/iTerm2 render MD natively
+
+**Decision:** Rejected - Markdown with Mermaid is sufficient.
+
+### Option C: PDF generation
+
+**Pros:**
+- Professional output
+- Fixed layout
+
+**Cons:**
+- Requires PDF library (heavy)
+- Not easily editable
+- Slower to generate
+
+**Decision:** Rejected - Can convert MD to PDF externally if needed.
+
+## Implementation
+
+### Files Added
+
+| File | Purpose |
+|------|---------|
+| `include/nous/output_service.h` | Public API |
+| `src/tools/output_service.c` | Implementation (~650 LOC) |
+| `tests/test_output_service.c` | Unit tests (20+ cases) |
+
+### Directory Structure
+
+```
+~/.convergio/outputs/
+├── 2025-12-16/
+│   ├── project-a/
+│   │   ├── analysis-abc123.md
+│   │   └── architecture-def456.md
+│   └── project-b/
+│       └── report-ghi789.md
+└── latest -> 2025-12-16/  (symlink)
+```
+
+### Templates
+
+Built-in templates:
+- `analysis` - Executive summary, findings, recommendations
+- `architecture` - Overview, components, data flow diagram
+- `report` - Introduction, background, methodology, results
+
+```c
+OutputResult result;
+output_from_template("analysis", "Security Analysis", NULL, &result);
+```
+
+## Consequences
+
+### Positive
+
+- **Consistent output** - All agents use same format
+- **Rich content** - Mermaid diagrams, tables
+- **Discoverable** - Organized by date/project
+- **Clickable** - OSC8 links in terminal
+- **Cleanable** - Auto-cleanup old outputs
+
+### Negative
+
+- **Disk usage** - Files accumulate (mitigated by cleanup)
+- **Learning curve** - New API for agents
+
+### Risks
+
+- **Mermaid rendering** - Not all viewers support it
+- **OSC8 support** - Some terminals don't support links
+
+## Testing
+
+Run tests: `make output_service_test`
+
+Coverage:
+- Document creation (all formats)
+- Mermaid diagram generation
+- Table generation
+- Template system
+- File management
+- OSC8 link generation
+
+## Usage Examples
+
+### Agent generating a report
+
+```c
+// Build content with table
+const char* headers[] = {"Component", "Status", "Notes"};
+const char* row1[] = {"Auth", "OK", "OAuth2 configured"};
+const char* row2[] = {"API", "Warning", "Rate limits needed"};
+const char** rows[] = {row1, row2, NULL};
+char* table = output_table_simple(headers, 3, (const char***)rows, 2);
+
+// Build content with diagram
+char* diagram = output_mermaid_flowchart("System Flow", "LR",
+    (const char*[]){"A[Client]", "B[API]", "C[DB]", NULL},
+    (const char*[]){"A --> B", "B --> C", NULL});
+
+// Create document
+char content[4096];
+snprintf(content, sizeof(content),
+    "## Status\n\n%s\n\n## Architecture\n\n```mermaid\n%s```\n",
+    table, diagram);
+
+OutputRequest req = {
+    .title = "System Status",
+    .content = content,
+    .agent_name = "baccio",
+    .include_timestamp = true
+};
+OutputResult result;
+output_create(&req, &result);
+
+// Show link to user
+output_print_link(result.filepath, "Status Report");
+
+free(table);
+free(diagram);
+```
+
+## Future Work
+
+1. **Agent integration** - Add output_service calls to key agents
+2. **CLI commands** - `convergio output list`, `convergio output open`
+3. **PDF export** - Optional PDF generation via external tool
+4. **Web preview** - Local server to preview outputs

--- a/include/nous/output_service.h
+++ b/include/nous/output_service.h
@@ -1,0 +1,374 @@
+/**
+ * CONVERGIO OUTPUT SERVICE
+ *
+ * Centralized service for generating structured output documents.
+ * Provides unified API for all agents to create rich Markdown files
+ * with Mermaid diagrams, tables, and terminal-friendly links.
+ *
+ * Features:
+ * - Markdown document generation
+ * - Mermaid diagram embedding (flowchart, sequence, gantt, etc.)
+ * - Table generation from structured data
+ * - OSC8 terminal hyperlinks for clickable file paths
+ * - Auto-organization by date/project
+ * - Cleanup policies for old outputs
+ */
+
+#ifndef CONVERGIO_OUTPUT_SERVICE_H
+#define CONVERGIO_OUTPUT_SERVICE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <time.h>
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+typedef enum {
+    OUTPUT_FORMAT_MARKDOWN,
+    OUTPUT_FORMAT_HTML,
+    OUTPUT_FORMAT_JSON,
+    OUTPUT_FORMAT_PLAIN
+} OutputFormat;
+
+typedef enum {
+    MERMAID_FLOWCHART,
+    MERMAID_SEQUENCE,
+    MERMAID_CLASS,
+    MERMAID_STATE,
+    MERMAID_ER,
+    MERMAID_GANTT,
+    MERMAID_PIE,
+    MERMAID_MINDMAP,
+    MERMAID_TIMELINE,
+    MERMAID_CUSTOM
+} MermaidType;
+
+typedef enum {
+    OUTPUT_OK = 0,
+    OUTPUT_ERROR_INIT,
+    OUTPUT_ERROR_IO,
+    OUTPUT_ERROR_INVALID,
+    OUTPUT_ERROR_MEMORY,
+    OUTPUT_ERROR_PATH
+} OutputError;
+
+// ============================================================================
+// DATA STRUCTURES
+// ============================================================================
+
+/**
+ * Output document request
+ */
+typedef struct {
+    const char* title;           // Document title (required)
+    const char* content;         // Main content in Markdown (required)
+    const char* agent_name;      // Name of agent creating the output
+    const char* project_context; // Optional project name for organization
+    OutputFormat format;         // Output format
+    bool open_after;             // Open file after creation
+    bool include_timestamp;      // Add timestamp header
+    bool include_toc;            // Generate table of contents
+} OutputRequest;
+
+/**
+ * Output result with file path and terminal link
+ */
+typedef struct {
+    bool success;
+    char filepath[1024];        // Absolute path to created file
+    char terminal_link[2048];   // OSC8 hyperlink for terminal display
+    char open_command[256];     // Command to open file manually
+    char relative_path[512];    // Path relative to outputs directory
+    time_t created_at;
+} OutputResult;
+
+/**
+ * Table column definition
+ */
+typedef struct {
+    const char* header;         // Column header text
+    int width;                  // Min width (0 for auto)
+    char align;                 // 'l'=left, 'r'=right, 'c'=center
+} TableColumn;
+
+/**
+ * Mermaid diagram configuration
+ */
+typedef struct {
+    MermaidType type;
+    const char* title;          // Optional diagram title
+    const char* content;        // Mermaid syntax content
+    const char* theme;          // Optional theme (default, dark, forest, neutral)
+} MermaidDiagram;
+
+// ============================================================================
+// INITIALIZATION
+// ============================================================================
+
+/**
+ * Initialize the output service
+ * Creates output directories if needed
+ *
+ * @param base_path  Base path for outputs (NULL for default ~/.convergio/outputs)
+ * @return           OUTPUT_OK on success
+ */
+OutputError output_service_init(const char* base_path);
+
+/**
+ * Shutdown output service and cleanup resources
+ */
+void output_service_shutdown(void);
+
+/**
+ * Check if service is initialized
+ */
+bool output_service_is_ready(void);
+
+/**
+ * Get the base output directory
+ */
+const char* output_service_get_base_path(void);
+
+// ============================================================================
+// DOCUMENT CREATION
+// ============================================================================
+
+/**
+ * Create a new output document
+ *
+ * @param request  Document configuration
+ * @param result   Output result (filepath, link, etc.)
+ * @return         OUTPUT_OK on success
+ */
+OutputError output_create(const OutputRequest* request, OutputResult* result);
+
+/**
+ * Append content to an existing output document
+ *
+ * @param filepath  Path to existing document
+ * @param content   Content to append
+ * @return          OUTPUT_OK on success
+ */
+OutputError output_append(const char* filepath, const char* content);
+
+/**
+ * Create a document with predefined template
+ *
+ * @param template_name  Template name (e.g., "analysis", "report", "architecture")
+ * @param title          Document title
+ * @param data           Key-value pairs for template substitution (NULL-terminated)
+ * @param result         Output result
+ * @return               OUTPUT_OK on success
+ */
+OutputError output_from_template(const char* template_name, const char* title,
+                                  const char** data, OutputResult* result);
+
+// ============================================================================
+// MERMAID DIAGRAMS
+// ============================================================================
+
+/**
+ * Generate Mermaid diagram code block
+ *
+ * @param diagram  Diagram configuration
+ * @return         Allocated Markdown code block, caller must free
+ */
+char* output_mermaid_block(const MermaidDiagram* diagram);
+
+/**
+ * Create a flowchart diagram
+ *
+ * @param title      Diagram title
+ * @param direction  "TB" (top-bottom), "BT", "LR" (left-right), "RL"
+ * @param nodes      Node definitions (A[Label], B{Decision}, etc.)
+ * @param edges      Edge definitions (A --> B, B -->|Yes| C, etc.)
+ * @return           Allocated Mermaid code, caller must free
+ */
+char* output_mermaid_flowchart(const char* title, const char* direction,
+                                const char** nodes, const char** edges);
+
+/**
+ * Create a sequence diagram
+ *
+ * @param title        Diagram title
+ * @param participants Array of participant names
+ * @param messages     Array of messages ("A->>B: message")
+ * @return             Allocated Mermaid code, caller must free
+ */
+char* output_mermaid_sequence(const char* title, const char** participants,
+                               const char** messages);
+
+/**
+ * Create a Gantt chart
+ *
+ * @param title    Chart title
+ * @param sections Array of section names
+ * @param tasks    Array of task definitions ("Task :done, t1, 2024-01-01, 3d")
+ * @return         Allocated Mermaid code, caller must free
+ */
+char* output_mermaid_gantt(const char* title, const char** sections,
+                            const char** tasks);
+
+/**
+ * Create a pie chart
+ *
+ * @param title  Chart title
+ * @param labels Array of labels
+ * @param values Array of values (as strings, e.g., "30")
+ * @param count  Number of items
+ * @return       Allocated Mermaid code, caller must free
+ */
+char* output_mermaid_pie(const char* title, const char** labels,
+                          const char** values, int count);
+
+/**
+ * Create a mindmap
+ *
+ * @param root     Root node text
+ * @param branches Nested branch definitions (indentation matters)
+ * @return         Allocated Mermaid code, caller must free
+ */
+char* output_mermaid_mindmap(const char* root, const char* branches);
+
+// ============================================================================
+// TABLE GENERATION
+// ============================================================================
+
+/**
+ * Generate a Markdown table
+ *
+ * @param columns    Column definitions
+ * @param col_count  Number of columns
+ * @param rows       2D array of cell values (row-major)
+ * @param row_count  Number of rows
+ * @return           Allocated Markdown table, caller must free
+ */
+char* output_table(const TableColumn* columns, int col_count,
+                   const char*** rows, int row_count);
+
+/**
+ * Generate a simple table from string arrays
+ *
+ * @param headers    Array of header strings
+ * @param col_count  Number of columns
+ * @param rows       2D array of cell values
+ * @param row_count  Number of rows
+ * @return           Allocated Markdown table, caller must free
+ */
+char* output_table_simple(const char** headers, int col_count,
+                           const char*** rows, int row_count);
+
+// ============================================================================
+// TERMINAL INTEGRATION
+// ============================================================================
+
+/**
+ * Print a file link to terminal (with OSC8 if supported)
+ *
+ * @param filepath  Path to file
+ * @param label     Display label (NULL uses filename)
+ */
+void output_print_link(const char* filepath, const char* label);
+
+/**
+ * Print multiple links as a list
+ *
+ * @param filepaths  Array of file paths
+ * @param labels     Array of labels (can be NULL)
+ * @param count      Number of items
+ */
+void output_print_links(const char** filepaths, const char** labels, int count);
+
+/**
+ * Get the terminal link string for a file
+ *
+ * @param filepath  Path to file
+ * @param label     Display label
+ * @return          Allocated link string, caller must free
+ */
+char* output_get_link(const char* filepath, const char* label);
+
+// ============================================================================
+// FILE MANAGEMENT
+// ============================================================================
+
+/**
+ * Get the latest output file
+ *
+ * @param result  Output result structure
+ * @return        OUTPUT_OK if found, OUTPUT_ERROR_NOT_FOUND otherwise
+ */
+OutputError output_get_latest(OutputResult* result);
+
+/**
+ * List recent outputs
+ *
+ * @param count       Maximum number of outputs to return
+ * @param out_paths   Output array for paths (caller allocates)
+ * @param out_count   Actual count returned
+ * @return            OUTPUT_OK on success
+ */
+OutputError output_list_recent(int count, char** out_paths, int* out_count);
+
+/**
+ * Delete an output file
+ *
+ * @param filepath  Path to output file
+ * @return          OUTPUT_OK on success
+ */
+OutputError output_delete(const char* filepath);
+
+/**
+ * Cleanup old outputs
+ *
+ * @param days_old  Delete outputs older than this many days
+ * @return          Number of files deleted
+ */
+int output_cleanup(int days_old);
+
+/**
+ * Get total size of output directory
+ *
+ * @return Size in bytes
+ */
+size_t output_get_total_size(void);
+
+// ============================================================================
+// CONVENIENCE MACROS
+// ============================================================================
+
+/**
+ * Quick output creation with defaults
+ */
+#define OUTPUT_QUICK(title, content) \
+    do { \
+        OutputRequest req = { .title = (title), .content = (content), \
+                              .format = OUTPUT_FORMAT_MARKDOWN, \
+                              .include_timestamp = true }; \
+        OutputResult res; \
+        output_create(&req, &res); \
+        if (res.success) output_print_link(res.filepath, NULL); \
+    } while(0)
+
+/**
+ * Output with Mermaid diagram
+ */
+#define OUTPUT_WITH_DIAGRAM(title, content, mermaid_content) \
+    do { \
+        char* _diagram = output_mermaid_block(&(MermaidDiagram){ \
+            .type = MERMAID_FLOWCHART, .content = (mermaid_content) \
+        }); \
+        size_t _len = strlen(content) + strlen(_diagram) + 4; \
+        char* _full = malloc(_len); \
+        snprintf(_full, _len, "%s\n\n%s", (content), _diagram); \
+        OutputRequest req = { .title = (title), .content = _full, \
+                              .format = OUTPUT_FORMAT_MARKDOWN }; \
+        OutputResult res; \
+        output_create(&req, &res); \
+        free(_full); free(_diagram); \
+        if (res.success) output_print_link(res.filepath, NULL); \
+    } while(0)
+
+#endif // CONVERGIO_OUTPUT_SERVICE_H

--- a/src/core/commands/commands.c
+++ b/src/core/commands/commands.c
@@ -22,6 +22,7 @@
 #include "nous/notify.h"
 #include "nous/mcp_client.h"
 #include "nous/plan_db.h"
+#include "nous/output_service.h"
 #include "../../auth/oauth.h"
 #include <cjson/cJSON.h>
 #include <stdio.h>
@@ -84,6 +85,9 @@ int cmd_style(int argc, char** argv);
 // Forward declaration for plan command
 int cmd_plan(int argc, char** argv);
 
+// Forward declaration for output command
+int cmd_output(int argc, char** argv);
+
 static const ReplCommand COMMANDS[] = {
     {"help",        "Show available commands",           cmd_help},
     {"agent",       "Manage agents",                     cmd_agent},
@@ -129,6 +133,8 @@ static const ReplCommand COMMANDS[] = {
     {"mcp",         "Manage MCP servers and tools",      cmd_mcp},
     // Execution Plan management
     {"plan",        "Manage execution plans (list/status/export)", cmd_plan},
+    // Output Service
+    {"output",      "Manage generated outputs (list/open/delete)", cmd_output},
     {"quit",        "Exit Convergio",                    cmd_quit},
     {"exit",        "Exit Convergio",                    cmd_quit},
     {NULL, NULL, NULL}
@@ -785,6 +791,26 @@ static const CommandHelp DETAILED_HELP[] = {
         "/plan status abc123          # Show plan details\n"
         "/plan export abc123          # Export to /tmp/plan-abc123.md\n"
         "/plan cleanup 7              # Delete plans older than 7 days"
+    },
+    {
+        "output",
+        "output <subcommand> [args]",
+        "Manage generated outputs",
+        "Browse, open, and manage generated output documents.\n"
+        "Outputs include reports, analyses, and diagrams created by agents.\n\n"
+        "Subcommands:\n"
+        "  list              List recent outputs\n"
+        "  latest            Show the most recent output\n"
+        "  open <path>       Open an output file in default app\n"
+        "  delete <path>     Delete an output file\n"
+        "  size              Show total storage used by outputs\n"
+        "  cleanup [days]    Clean up old outputs (default: 30 days)\n\n"
+        "Outputs are stored in ~/.convergio/outputs/",
+        "/output list                 # Show recent outputs\n"
+        "/output latest               # Show the latest output\n"
+        "/output open /path/to/file   # Open in default app\n"
+        "/output size                 # Show disk usage\n"
+        "/output cleanup 7            # Delete outputs older than 7 days"
     },
     {NULL, NULL, NULL, NULL, NULL}
 };
@@ -4358,5 +4384,167 @@ int cmd_plan(int argc, char** argv) {
 
     printf("\033[31mUnknown plan command: %s\033[0m\n", subcmd);
     printf("Use '/plan' to see available commands.\n");
+    return -1;
+}
+
+// ============================================================================
+// OUTPUT COMMAND
+// ============================================================================
+
+/**
+ * /output - Output service management
+ *
+ * Subcommands:
+ *   list              List recent outputs
+ *   open <file>       Open an output file
+ *   delete <file>     Delete an output file
+ *   size              Show total size of outputs
+ *   cleanup [days]    Clean up old outputs (default: 30 days)
+ */
+int cmd_output(int argc, char** argv) {
+    if (!output_service_is_ready()) {
+        printf("\033[31m✗ Output service not initialized.\033[0m\n");
+        return -1;
+    }
+
+    if (argc < 2) {
+        printf("\n\033[1m📄 Output Service Manager\033[0m\n\n");
+        printf("Usage: output <subcommand> [args]\n\n");
+        printf("Subcommands:\n");
+        printf("  list              List recent outputs\n");
+        printf("  latest            Show latest output\n");
+        printf("  open <path>       Open an output file\n");
+        printf("  delete <path>     Delete an output file\n");
+        printf("  size              Show total size of outputs\n");
+        printf("  cleanup [days]    Clean up old outputs (default: 30)\n");
+        printf("\nOutputs are stored in ~/.convergio/outputs/\n\n");
+        return 0;
+    }
+
+    const char* subcmd = argv[1];
+
+    // --- output list ---
+    if (strcmp(subcmd, "list") == 0) {
+        printf("\n\033[1m📄 Recent Outputs\033[0m\n");
+        printf("──────────────────────────────────────────────────────────\n");
+
+        char* paths[20];
+        int count = 0;
+        OutputError err = output_list_recent(20, paths, &count);
+
+        if (err != OUTPUT_OK || count == 0) {
+            printf("  \033[90mNo outputs found.\033[0m\n\n");
+            return 0;
+        }
+
+        for (int i = 0; i < count; i++) {
+            // Extract filename from path
+            const char* filename = strrchr(paths[i], '/');
+            filename = filename ? filename + 1 : paths[i];
+
+            // Determine icon based on format
+            const char* icon = "📄";
+            if (strstr(filename, ".md")) icon = "📝";
+            else if (strstr(filename, ".json")) icon = "📊";
+            else if (strstr(filename, ".html")) icon = "🌐";
+
+            printf("  %s %s\n", icon, filename);
+            printf("     \033[90m%s\033[0m\n", paths[i]);
+
+            free(paths[i]);
+        }
+
+        printf("\n  Total: %d file(s)\n\n", count);
+        return 0;
+    }
+
+    // --- output latest ---
+    if (strcmp(subcmd, "latest") == 0) {
+        OutputResult result;
+        OutputError err = output_get_latest(&result);
+
+        if (err != OUTPUT_OK) {
+            printf("\033[31m✗ No recent outputs found.\033[0m\n");
+            return -1;
+        }
+
+        printf("\n\033[1m📄 Latest Output\033[0m\n");
+        printf("──────────────────────────────────────────────────────────\n");
+        printf("  Path: %s\n", result.filepath);
+        output_print_link(result.filepath, "Open in default app");
+        printf("\n");
+        return 0;
+    }
+
+    // --- output open ---
+    if (strcmp(subcmd, "open") == 0) {
+        if (argc < 3) {
+            printf("\033[31mUsage: output open <filepath>\033[0m\n");
+            printf("Use 'output list' to see available files.\n");
+            return -1;
+        }
+
+        const char* filepath = argv[2];
+
+        // Open with system default
+        char cmd[PATH_MAX + 16];
+        snprintf(cmd, sizeof(cmd), "open \"%s\"", filepath);
+        int ret = system(cmd);
+
+        if (ret == 0) {
+            printf("\033[32m✓ Opened: %s\033[0m\n", filepath);
+        } else {
+            printf("\033[31m✗ Failed to open file\033[0m\n");
+            return -1;
+        }
+        return 0;
+    }
+
+    // --- output delete ---
+    if (strcmp(subcmd, "delete") == 0) {
+        if (argc < 3) {
+            printf("\033[31mUsage: output delete <filepath>\033[0m\n");
+            return -1;
+        }
+
+        const char* filepath = argv[2];
+        OutputError err = output_delete(filepath);
+
+        if (err == OUTPUT_OK) {
+            printf("\033[32m✓ Deleted: %s\033[0m\n", filepath);
+        } else {
+            printf("\033[31m✗ Delete failed (file not found?)\033[0m\n");
+            return -1;
+        }
+        return 0;
+    }
+
+    // --- output size ---
+    if (strcmp(subcmd, "size") == 0) {
+        size_t total_size = output_get_total_size();
+        float size_mb = (float)total_size / (1024.0f * 1024.0f);
+
+        printf("\n\033[1m📊 Output Storage\033[0m\n");
+        printf("──────────────────────────────────────────────────────────\n");
+        printf("  Total size: %.2f MB\n", size_mb);
+        printf("  Location: ~/.convergio/outputs/\n\n");
+        return 0;
+    }
+
+    // --- output cleanup ---
+    if (strcmp(subcmd, "cleanup") == 0) {
+        int days = 30;
+        if (argc >= 3) {
+            days = atoi(argv[2]);
+            if (days <= 0) days = 30;
+        }
+
+        int deleted = output_cleanup(days);
+        printf("\033[32m✓ Cleaned up %d file(s) older than %d days\033[0m\n", deleted, days);
+        return 0;
+    }
+
+    printf("\033[31mUnknown output command: %s\033[0m\n", subcmd);
+    printf("Use '/output' to see available commands.\n");
     return -1;
 }

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -22,6 +22,7 @@
 #include "nous/mlx.h"
 #include "nous/notify.h"
 #include "nous/plan_db.h"
+#include "nous/output_service.h"
 #include "../auth/oauth.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -503,6 +504,12 @@ int main(int argc, char** argv) {
         // Non-critical: plans will work in-memory only
     }
 
+    // Initialize Output Service for structured document generation
+    if (output_service_init(NULL) != OUTPUT_OK) {
+        fprintf(stderr, "  \033[33m⚠ Output service initialization failed (non-critical)\033[0m\n");
+        // Non-critical: agents will output to terminal only
+    }
+
     // Set local MLX mode if requested
     if (g_use_local_mlx) {
         const char* model_id = g_mlx_model[0] ? g_mlx_model : "deepseek-r1-1.5b";
@@ -701,6 +708,9 @@ int main(int argc, char** argv) {
 
     // Shutdown Plan Database
     plan_db_shutdown();
+
+    // Shutdown Output Service
+    output_service_shutdown();
 
     // Shutdown agent configs and orchestrator
     extern void agent_config_shutdown(void);

--- a/src/tools/output_service.c
+++ b/src/tools/output_service.c
@@ -1,0 +1,760 @@
+/**
+ * CONVERGIO OUTPUT SERVICE
+ *
+ * Centralized service for generating structured output documents.
+ */
+
+#include "nous/output_service.h"
+#include "nous/hyperlink.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <time.h>
+#include <uuid/uuid.h>
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+#define MAX_PATH_LEN 1024
+#define MAX_FILENAME_LEN 256
+#define DEFAULT_OUTPUT_DIR "outputs"
+
+// ============================================================================
+// GLOBAL STATE
+// ============================================================================
+
+static char g_base_path[MAX_PATH_LEN] = {0};
+static bool g_initialized = false;
+
+// ============================================================================
+// INTERNAL HELPERS
+// ============================================================================
+
+static void generate_short_id(char* out, size_t len) {
+    uuid_t uuid;
+    uuid_generate(uuid);
+    char full[37];
+    uuid_unparse_lower(uuid, full);
+    // Take first 8 chars
+    strncpy(out, full, len - 1);
+    out[len - 1] = '\0';
+}
+
+static void get_date_path(char* out, size_t len) {
+    time_t now = time(NULL);
+    struct tm* tm_info = localtime(&now);
+    strftime(out, len, "%Y-%m-%d", tm_info);
+}
+
+static void get_timestamp_str(char* out, size_t len) {
+    time_t now = time(NULL);
+    struct tm* tm_info = localtime(&now);
+    strftime(out, len, "%Y-%m-%d %H:%M:%S", tm_info);
+}
+
+static void ensure_directory(const char* path) {
+    char tmp[MAX_PATH_LEN];
+    char* p = NULL;
+    size_t len;
+
+    snprintf(tmp, sizeof(tmp), "%s", path);
+    len = strlen(tmp);
+    if (tmp[len - 1] == '/') tmp[len - 1] = '\0';
+
+    for (p = tmp + 1; *p; p++) {
+        if (*p == '/') {
+            *p = '\0';
+            mkdir(tmp, 0755);
+            *p = '/';
+        }
+    }
+    mkdir(tmp, 0755);
+}
+
+static char* sanitize_filename(const char* title) {
+    if (!title) return strdup("output");
+
+    size_t len = strlen(title);
+    char* result = malloc(len + 1);
+    size_t j = 0;
+
+    for (size_t i = 0; i < len && j < 50; i++) {
+        char c = title[i];
+        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+            (c >= '0' && c <= '9') || c == '-' || c == '_') {
+            result[j++] = c;
+        } else if (c == ' ') {
+            result[j++] = '-';
+        }
+    }
+    result[j] = '\0';
+
+    // Lowercase
+    for (size_t i = 0; i < j; i++) {
+        if (result[i] >= 'A' && result[i] <= 'Z') {
+            result[i] = result[i] + ('a' - 'A');
+        }
+    }
+
+    if (j == 0) {
+        free(result);
+        return strdup("output");
+    }
+
+    return result;
+}
+
+static const char* get_format_extension(OutputFormat format) {
+    switch (format) {
+        case OUTPUT_FORMAT_MARKDOWN: return ".md";
+        case OUTPUT_FORMAT_HTML: return ".html";
+        case OUTPUT_FORMAT_JSON: return ".json";
+        case OUTPUT_FORMAT_PLAIN: return ".txt";
+        default: return ".md";
+    }
+}
+
+static const char* get_mermaid_type_string(MermaidType type) {
+    switch (type) {
+        case MERMAID_FLOWCHART: return "flowchart TD";
+        case MERMAID_SEQUENCE: return "sequenceDiagram";
+        case MERMAID_CLASS: return "classDiagram";
+        case MERMAID_STATE: return "stateDiagram-v2";
+        case MERMAID_ER: return "erDiagram";
+        case MERMAID_GANTT: return "gantt";
+        case MERMAID_PIE: return "pie";
+        case MERMAID_MINDMAP: return "mindmap";
+        case MERMAID_TIMELINE: return "timeline";
+        case MERMAID_CUSTOM: return "";
+        default: return "flowchart TD";
+    }
+}
+
+// ============================================================================
+// INITIALIZATION
+// ============================================================================
+
+OutputError output_service_init(const char* base_path) {
+    if (g_initialized) return OUTPUT_OK;
+
+    if (base_path && base_path[0]) {
+        snprintf(g_base_path, sizeof(g_base_path), "%s", base_path);
+    } else {
+        const char* home = getenv("HOME");
+        if (!home) home = "/tmp";
+        snprintf(g_base_path, sizeof(g_base_path), "%s/.convergio/%s", home, DEFAULT_OUTPUT_DIR);
+    }
+
+    // Create base directory
+    ensure_directory(g_base_path);
+
+    g_initialized = true;
+    return OUTPUT_OK;
+}
+
+void output_service_shutdown(void) {
+    g_initialized = false;
+}
+
+bool output_service_is_ready(void) {
+    return g_initialized;
+}
+
+const char* output_service_get_base_path(void) {
+    return g_base_path;
+}
+
+// ============================================================================
+// DOCUMENT CREATION
+// ============================================================================
+
+OutputError output_create(const OutputRequest* request, OutputResult* result) {
+    if (!g_initialized) {
+        output_service_init(NULL);
+    }
+
+    if (!request || !request->title || !request->content || !result) {
+        return OUTPUT_ERROR_INVALID;
+    }
+
+    memset(result, 0, sizeof(OutputResult));
+
+    // Build directory path (base/date/project)
+    char date_str[16];
+    get_date_path(date_str, sizeof(date_str));
+
+    char dir_path[MAX_PATH_LEN];
+    if (request->project_context && request->project_context[0]) {
+        char* safe_project = sanitize_filename(request->project_context);
+        snprintf(dir_path, sizeof(dir_path), "%s/%s/%s", g_base_path, date_str, safe_project);
+        free(safe_project);
+    } else {
+        snprintf(dir_path, sizeof(dir_path), "%s/%s", g_base_path, date_str);
+    }
+
+    ensure_directory(dir_path);
+
+    // Build filename
+    char* safe_title = sanitize_filename(request->title);
+    char short_id[9];
+    generate_short_id(short_id, sizeof(short_id));
+    const char* ext = get_format_extension(request->format);
+
+    snprintf(result->filepath, sizeof(result->filepath), "%s/%s-%s%s",
+             dir_path, safe_title, short_id, ext);
+
+    // Build relative path
+    snprintf(result->relative_path, sizeof(result->relative_path), "%s/%s-%s%s",
+             date_str, safe_title, short_id, ext);
+
+    free(safe_title);
+
+    // Create file
+    FILE* f = fopen(result->filepath, "w");
+    if (!f) {
+        return OUTPUT_ERROR_IO;
+    }
+
+    // Write header if markdown
+    if (request->format == OUTPUT_FORMAT_MARKDOWN) {
+        fprintf(f, "# %s\n\n", request->title);
+
+        if (request->include_timestamp) {
+            char timestamp[32];
+            get_timestamp_str(timestamp, sizeof(timestamp));
+            fprintf(f, "_Generated: %s_", timestamp);
+            if (request->agent_name) {
+                fprintf(f, " | _Agent: %s_", request->agent_name);
+            }
+            fprintf(f, "\n\n---\n\n");
+        }
+    }
+
+    // Write content
+    fprintf(f, "%s\n", request->content);
+    fclose(f);
+
+    // Set result
+    result->success = true;
+    result->created_at = time(NULL);
+
+    // Generate terminal link
+    char* link = hyperlink_file(result->filepath, request->title);
+    if (link) {
+        snprintf(result->terminal_link, sizeof(result->terminal_link), "%s", link);
+        free(link);
+    }
+
+    // Open command
+    snprintf(result->open_command, sizeof(result->open_command), "open \"%s\"", result->filepath);
+
+    // Open if requested
+    if (request->open_after) {
+        system(result->open_command);
+    }
+
+    return OUTPUT_OK;
+}
+
+OutputError output_append(const char* filepath, const char* content) {
+    if (!filepath || !content) return OUTPUT_ERROR_INVALID;
+
+    FILE* f = fopen(filepath, "a");
+    if (!f) return OUTPUT_ERROR_IO;
+
+    fprintf(f, "\n%s", content);
+    fclose(f);
+
+    return OUTPUT_OK;
+}
+
+OutputError output_from_template(const char* template_name, const char* title,
+                                  const char** data, OutputResult* result) {
+    if (!template_name || !title || !result) return OUTPUT_ERROR_INVALID;
+
+    // Simple templates
+    char content[8192];
+
+    if (strcmp(template_name, "analysis") == 0) {
+        snprintf(content, sizeof(content),
+            "## Executive Summary\n\n"
+            "[Summary here]\n\n"
+            "## Key Findings\n\n"
+            "1. Finding 1\n"
+            "2. Finding 2\n"
+            "3. Finding 3\n\n"
+            "## Recommendations\n\n"
+            "- Recommendation 1\n"
+            "- Recommendation 2\n\n"
+            "## Next Steps\n\n"
+            "- [ ] Action item 1\n"
+            "- [ ] Action item 2\n");
+    } else if (strcmp(template_name, "architecture") == 0) {
+        snprintf(content, sizeof(content),
+            "## Overview\n\n"
+            "[Architecture description]\n\n"
+            "## Components\n\n"
+            "### Component 1\n\n"
+            "Description here.\n\n"
+            "### Component 2\n\n"
+            "Description here.\n\n"
+            "## Data Flow\n\n"
+            "```mermaid\n"
+            "flowchart LR\n"
+            "    A[Input] --> B[Process]\n"
+            "    B --> C[Output]\n"
+            "```\n\n"
+            "## Dependencies\n\n"
+            "| Component | Depends On | Purpose |\n"
+            "|-----------|------------|----------|\n"
+            "| A | B | Description |\n");
+    } else if (strcmp(template_name, "report") == 0) {
+        snprintf(content, sizeof(content),
+            "## Introduction\n\n"
+            "[Introduction]\n\n"
+            "## Background\n\n"
+            "[Background]\n\n"
+            "## Methodology\n\n"
+            "[Methodology]\n\n"
+            "## Results\n\n"
+            "[Results]\n\n"
+            "## Conclusion\n\n"
+            "[Conclusion]\n\n"
+            "## References\n\n"
+            "1. Reference 1\n"
+            "2. Reference 2\n");
+    } else {
+        snprintf(content, sizeof(content),
+            "## Content\n\n"
+            "[Add your content here]\n");
+    }
+
+    OutputRequest request = {
+        .title = title,
+        .content = content,
+        .format = OUTPUT_FORMAT_MARKDOWN,
+        .include_timestamp = true
+    };
+
+    return output_create(&request, result);
+}
+
+// ============================================================================
+// MERMAID DIAGRAMS
+// ============================================================================
+
+char* output_mermaid_block(const MermaidDiagram* diagram) {
+    if (!diagram || !diagram->content) return NULL;
+
+    const char* type_str = get_mermaid_type_string(diagram->type);
+
+    size_t len = strlen(type_str) + strlen(diagram->content) + 64;
+    if (diagram->title) len += strlen(diagram->title) + 20;
+
+    char* result = malloc(len);
+    if (!result) return NULL;
+
+    size_t pos = 0;
+
+    // Title comment if provided
+    if (diagram->title) {
+        pos += snprintf(result + pos, len - pos, "<!-- %s -->\n", diagram->title);
+    }
+
+    pos += snprintf(result + pos, len - pos, "```mermaid\n");
+
+    if (diagram->type != MERMAID_CUSTOM) {
+        pos += snprintf(result + pos, len - pos, "%s\n", type_str);
+    }
+
+    pos += snprintf(result + pos, len - pos, "%s\n```", diagram->content);
+
+    return result;
+}
+
+char* output_mermaid_flowchart(const char* title, const char* direction,
+                                const char** nodes, const char** edges) {
+    if (!direction) direction = "TD";
+
+    size_t buf_size = 4096;
+    char* buf = malloc(buf_size);
+    if (!buf) return NULL;
+
+    size_t pos = 0;
+
+    if (title) {
+        pos += snprintf(buf + pos, buf_size - pos, "---\ntitle: %s\n---\n", title);
+    }
+
+    pos += snprintf(buf + pos, buf_size - pos, "flowchart %s\n", direction);
+
+    // Add nodes
+    if (nodes) {
+        for (int i = 0; nodes[i]; i++) {
+            pos += snprintf(buf + pos, buf_size - pos, "    %s\n", nodes[i]);
+        }
+    }
+
+    // Add edges
+    if (edges) {
+        for (int i = 0; edges[i]; i++) {
+            pos += snprintf(buf + pos, buf_size - pos, "    %s\n", edges[i]);
+        }
+    }
+
+    return buf;
+}
+
+char* output_mermaid_sequence(const char* title, const char** participants,
+                               const char** messages) {
+    size_t buf_size = 4096;
+    char* buf = malloc(buf_size);
+    if (!buf) return NULL;
+
+    size_t pos = 0;
+
+    if (title) {
+        pos += snprintf(buf + pos, buf_size - pos, "---\ntitle: %s\n---\n", title);
+    }
+
+    pos += snprintf(buf + pos, buf_size - pos, "sequenceDiagram\n");
+
+    // Add participants
+    if (participants) {
+        for (int i = 0; participants[i]; i++) {
+            pos += snprintf(buf + pos, buf_size - pos, "    participant %s\n", participants[i]);
+        }
+    }
+
+    // Add messages
+    if (messages) {
+        for (int i = 0; messages[i]; i++) {
+            pos += snprintf(buf + pos, buf_size - pos, "    %s\n", messages[i]);
+        }
+    }
+
+    return buf;
+}
+
+char* output_mermaid_gantt(const char* title, const char** sections,
+                            const char** tasks) {
+    size_t buf_size = 4096;
+    char* buf = malloc(buf_size);
+    if (!buf) return NULL;
+
+    size_t pos = 0;
+
+    pos += snprintf(buf + pos, buf_size - pos, "gantt\n");
+
+    if (title) {
+        pos += snprintf(buf + pos, buf_size - pos, "    title %s\n", title);
+    }
+
+    pos += snprintf(buf + pos, buf_size - pos, "    dateFormat YYYY-MM-DD\n");
+
+    // Add sections and tasks
+    int section_idx = 0;
+    if (sections && tasks) {
+        for (int i = 0; tasks[i]; i++) {
+            // Check if we need a new section
+            if (sections[section_idx] && strncmp(tasks[i], "section:", 8) == 0) {
+                pos += snprintf(buf + pos, buf_size - pos, "    section %s\n", sections[section_idx]);
+                section_idx++;
+            }
+            pos += snprintf(buf + pos, buf_size - pos, "    %s\n", tasks[i]);
+        }
+    } else if (tasks) {
+        for (int i = 0; tasks[i]; i++) {
+            pos += snprintf(buf + pos, buf_size - pos, "    %s\n", tasks[i]);
+        }
+    }
+
+    return buf;
+}
+
+char* output_mermaid_pie(const char* title, const char** labels,
+                          const char** values, int count) {
+    if (!labels || !values || count <= 0) return NULL;
+
+    size_t buf_size = 2048;
+    char* buf = malloc(buf_size);
+    if (!buf) return NULL;
+
+    size_t pos = 0;
+
+    pos += snprintf(buf + pos, buf_size - pos, "pie showData\n");
+
+    if (title) {
+        pos += snprintf(buf + pos, buf_size - pos, "    title %s\n", title);
+    }
+
+    for (int i = 0; i < count && labels[i] && values[i]; i++) {
+        pos += snprintf(buf + pos, buf_size - pos, "    \"%s\" : %s\n", labels[i], values[i]);
+    }
+
+    return buf;
+}
+
+char* output_mermaid_mindmap(const char* root, const char* branches) {
+    if (!root) return NULL;
+
+    size_t len = strlen(root) + (branches ? strlen(branches) : 0) + 64;
+    char* buf = malloc(len);
+    if (!buf) return NULL;
+
+    if (branches) {
+        snprintf(buf, len, "mindmap\n  root((%s))\n%s", root, branches);
+    } else {
+        snprintf(buf, len, "mindmap\n  root((%s))", root);
+    }
+
+    return buf;
+}
+
+// ============================================================================
+// TABLE GENERATION
+// ============================================================================
+
+char* output_table(const TableColumn* columns, int col_count,
+                   const char*** rows, int row_count) {
+    if (!columns || col_count <= 0) return NULL;
+
+    size_t buf_size = 8192;
+    char* buf = malloc(buf_size);
+    if (!buf) return NULL;
+
+    size_t pos = 0;
+
+    // Header row
+    pos += snprintf(buf + pos, buf_size - pos, "|");
+    for (int i = 0; i < col_count; i++) {
+        pos += snprintf(buf + pos, buf_size - pos, " %s |", columns[i].header ? columns[i].header : "");
+    }
+    pos += snprintf(buf + pos, buf_size - pos, "\n|");
+
+    // Separator row with alignment
+    for (int i = 0; i < col_count; i++) {
+        char align_left = '-';
+        char align_right = '-';
+        if (columns[i].align == 'c') {
+            align_left = ':';
+            align_right = ':';
+        } else if (columns[i].align == 'r') {
+            align_right = ':';
+        } else {
+            align_left = ':';
+        }
+        pos += snprintf(buf + pos, buf_size - pos, "%c---%c|", align_left, align_right);
+    }
+    pos += snprintf(buf + pos, buf_size - pos, "\n");
+
+    // Data rows
+    if (rows) {
+        for (int r = 0; r < row_count && rows[r]; r++) {
+            pos += snprintf(buf + pos, buf_size - pos, "|");
+            for (int c = 0; c < col_count; c++) {
+                const char* cell = (rows[r] && rows[r][c]) ? rows[r][c] : "";
+                pos += snprintf(buf + pos, buf_size - pos, " %s |", cell);
+            }
+            pos += snprintf(buf + pos, buf_size - pos, "\n");
+        }
+    }
+
+    return buf;
+}
+
+char* output_table_simple(const char** headers, int col_count,
+                           const char*** rows, int row_count) {
+    if (!headers || col_count <= 0) return NULL;
+
+    // Create column definitions with defaults
+    TableColumn* columns = malloc(sizeof(TableColumn) * col_count);
+    for (int i = 0; i < col_count; i++) {
+        columns[i].header = headers[i];
+        columns[i].width = 0;
+        columns[i].align = 'l';
+    }
+
+    char* result = output_table(columns, col_count, rows, row_count);
+    free(columns);
+    return result;
+}
+
+// ============================================================================
+// TERMINAL INTEGRATION
+// ============================================================================
+
+void output_print_link(const char* filepath, const char* label) {
+    if (!filepath) return;
+
+    char* link = hyperlink_file(filepath, label);
+    if (link) {
+        printf("\xF0\x9F\x93\x84 %s\n", link); // 📄 emoji
+        free(link);
+    } else {
+        printf("\xF0\x9F\x93\x84 %s\n", filepath);
+    }
+}
+
+void output_print_links(const char** filepaths, const char** labels, int count) {
+    printf("\n");
+    for (int i = 0; i < count && filepaths[i]; i++) {
+        const char* label = (labels && labels[i]) ? labels[i] : NULL;
+        printf("  ");
+        output_print_link(filepaths[i], label);
+    }
+    printf("\n");
+}
+
+char* output_get_link(const char* filepath, const char* label) {
+    if (!filepath) return NULL;
+    return hyperlink_file(filepath, label);
+}
+
+// ============================================================================
+// FILE MANAGEMENT
+// ============================================================================
+
+OutputError output_get_latest(OutputResult* result) {
+    if (!g_initialized || !result) return OUTPUT_ERROR_INVALID;
+
+    memset(result, 0, sizeof(OutputResult));
+
+    // Find most recent file in outputs directory
+    DIR* dir = opendir(g_base_path);
+    if (!dir) return OUTPUT_ERROR_IO;
+
+    time_t latest_time = 0;
+    char latest_path[MAX_PATH_LEN] = {0};
+
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != NULL) {
+        if (entry->d_name[0] == '.') continue;
+
+        char full_path[MAX_PATH_LEN];
+        snprintf(full_path, sizeof(full_path), "%s/%s", g_base_path, entry->d_name);
+
+        struct stat st;
+        if (stat(full_path, &st) == 0) {
+            if (st.st_mtime > latest_time) {
+                latest_time = st.st_mtime;
+                strncpy(latest_path, full_path, sizeof(latest_path) - 1);
+            }
+        }
+    }
+
+    closedir(dir);
+
+    if (latest_path[0] == '\0') {
+        return OUTPUT_ERROR_PATH;
+    }
+
+    strncpy(result->filepath, latest_path, sizeof(result->filepath) - 1);
+    result->success = true;
+    result->created_at = latest_time;
+
+    char* link = hyperlink_file(result->filepath, NULL);
+    if (link) {
+        strncpy(result->terminal_link, link, sizeof(result->terminal_link) - 1);
+        free(link);
+    }
+
+    return OUTPUT_OK;
+}
+
+OutputError output_list_recent(int count, char** out_paths, int* out_count) {
+    if (!g_initialized || !out_paths || !out_count || count <= 0) {
+        return OUTPUT_ERROR_INVALID;
+    }
+
+    *out_count = 0;
+
+    // Simple implementation: just list files from base directory
+    DIR* dir = opendir(g_base_path);
+    if (!dir) return OUTPUT_ERROR_IO;
+
+    struct dirent* entry;
+    int found = 0;
+
+    while ((entry = readdir(dir)) != NULL && found < count) {
+        if (entry->d_name[0] == '.') continue;
+
+        char full_path[MAX_PATH_LEN];
+        snprintf(full_path, sizeof(full_path), "%s/%s", g_base_path, entry->d_name);
+
+        out_paths[found] = strdup(full_path);
+        found++;
+    }
+
+    closedir(dir);
+    *out_count = found;
+
+    return OUTPUT_OK;
+}
+
+OutputError output_delete(const char* filepath) {
+    if (!filepath) return OUTPUT_ERROR_INVALID;
+
+    if (unlink(filepath) != 0) {
+        return OUTPUT_ERROR_IO;
+    }
+
+    return OUTPUT_OK;
+}
+
+int output_cleanup(int days_old) {
+    if (!g_initialized || days_old < 0) return 0;
+
+    time_t cutoff = time(NULL) - (days_old * 24 * 60 * 60);
+    int deleted = 0;
+
+    DIR* dir = opendir(g_base_path);
+    if (!dir) return 0;
+
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != NULL) {
+        if (entry->d_name[0] == '.') continue;
+
+        char full_path[MAX_PATH_LEN];
+        snprintf(full_path, sizeof(full_path), "%s/%s", g_base_path, entry->d_name);
+
+        struct stat st;
+        if (stat(full_path, &st) == 0 && st.st_mtime < cutoff) {
+            if (unlink(full_path) == 0) {
+                deleted++;
+            }
+        }
+    }
+
+    closedir(dir);
+    return deleted;
+}
+
+size_t output_get_total_size(void) {
+    if (!g_initialized) return 0;
+
+    size_t total = 0;
+
+    DIR* dir = opendir(g_base_path);
+    if (!dir) return 0;
+
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != NULL) {
+        if (entry->d_name[0] == '.') continue;
+
+        char full_path[MAX_PATH_LEN];
+        snprintf(full_path, sizeof(full_path), "%s/%s", g_base_path, entry->d_name);
+
+        struct stat st;
+        if (stat(full_path, &st) == 0) {
+            total += st.st_size;
+        }
+    }
+
+    closedir(dir);
+    return total;
+}

--- a/tests/test_output_service.c
+++ b/tests/test_output_service.c
@@ -1,0 +1,606 @@
+/**
+ * CONVERGIO OUTPUT SERVICE TESTS
+ *
+ * Unit tests for centralized output document generation
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include "nous/output_service.h"
+
+// ============================================================================
+// TEST MACROS
+// ============================================================================
+
+#define TEST(name) static void test_##name(void)
+#define RUN_TEST(name) do { \
+    printf("  Running %s...", #name); \
+    fflush(stdout); \
+    test_##name(); \
+    printf(" OK\n"); \
+} while(0)
+
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "\n    ASSERT FAILED: %s (line %d)\n", #cond, __LINE__); \
+        exit(1); \
+    } \
+} while(0)
+
+#define ASSERT_EQ(a, b) ASSERT((a) == (b))
+#define ASSERT_NE(a, b) ASSERT((a) != (b))
+#define ASSERT_STR_CONTAINS(haystack, needle) ASSERT(strstr((haystack), (needle)) != NULL)
+
+// ============================================================================
+// TEST FIXTURES
+// ============================================================================
+
+static const char* TEST_OUTPUT_DIR = "/tmp/convergio_test_outputs";
+
+static void setup(void) {
+    // Clean up old test directory
+    char cmd[256];
+    snprintf(cmd, sizeof(cmd), "rm -rf %s", TEST_OUTPUT_DIR);
+    system(cmd);
+
+    // Initialize service
+    OutputError err = output_service_init(TEST_OUTPUT_DIR);
+    ASSERT_EQ(err, OUTPUT_OK);
+    ASSERT(output_service_is_ready());
+}
+
+static void teardown(void) {
+    output_service_shutdown();
+
+    char cmd[256];
+    snprintf(cmd, sizeof(cmd), "rm -rf %s", TEST_OUTPUT_DIR);
+    system(cmd);
+}
+
+static char* read_file(const char* path) {
+    FILE* f = fopen(path, "r");
+    if (!f) return NULL;
+
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    char* content = malloc(size + 1);
+    fread(content, 1, size, f);
+    content[size] = '\0';
+    fclose(f);
+
+    return content;
+}
+
+// ============================================================================
+// INITIALIZATION TESTS
+// ============================================================================
+
+TEST(init_service) {
+    ASSERT(output_service_is_ready());
+
+    const char* base = output_service_get_base_path();
+    ASSERT(base != NULL);
+    ASSERT(strlen(base) > 0);
+
+    // Directory should exist
+    struct stat st;
+    ASSERT_EQ(stat(base, &st), 0);
+    ASSERT(S_ISDIR(st.st_mode));
+}
+
+// ============================================================================
+// DOCUMENT CREATION TESTS
+// ============================================================================
+
+TEST(create_simple_document) {
+    OutputRequest req = {
+        .title = "Test Document",
+        .content = "This is a test document.\n\nWith multiple paragraphs.",
+        .format = OUTPUT_FORMAT_MARKDOWN,
+        .include_timestamp = true
+    };
+
+    OutputResult result;
+    OutputError err = output_create(&req, &result);
+
+    ASSERT_EQ(err, OUTPUT_OK);
+    ASSERT(result.success);
+    ASSERT(strlen(result.filepath) > 0);
+    ASSERT(strlen(result.terminal_link) > 0);
+
+    // File should exist
+    struct stat st;
+    ASSERT_EQ(stat(result.filepath, &st), 0);
+
+    // Content should include title and content
+    char* content = read_file(result.filepath);
+    ASSERT(content != NULL);
+    ASSERT_STR_CONTAINS(content, "# Test Document");
+    ASSERT_STR_CONTAINS(content, "This is a test document");
+    ASSERT_STR_CONTAINS(content, "Generated:");
+    free(content);
+}
+
+TEST(create_document_with_agent) {
+    OutputRequest req = {
+        .title = "Agent Report",
+        .content = "Analysis complete.",
+        .agent_name = "baccio-architect",
+        .format = OUTPUT_FORMAT_MARKDOWN,
+        .include_timestamp = true
+    };
+
+    OutputResult result;
+    OutputError err = output_create(&req, &result);
+
+    ASSERT_EQ(err, OUTPUT_OK);
+    ASSERT(result.success);
+
+    char* content = read_file(result.filepath);
+    ASSERT(content != NULL);
+    ASSERT_STR_CONTAINS(content, "baccio-architect");
+    free(content);
+}
+
+TEST(create_document_with_project_context) {
+    OutputRequest req = {
+        .title = "Project Analysis",
+        .content = "Project content here.",
+        .project_context = "MyProject",
+        .format = OUTPUT_FORMAT_MARKDOWN
+    };
+
+    OutputResult result;
+    OutputError err = output_create(&req, &result);
+
+    ASSERT_EQ(err, OUTPUT_OK);
+    ASSERT(result.success);
+
+    // Path should contain project name
+    ASSERT_STR_CONTAINS(result.filepath, "myproject");
+}
+
+TEST(create_plain_text) {
+    OutputRequest req = {
+        .title = "Plain Output",
+        .content = "Just plain text.",
+        .format = OUTPUT_FORMAT_PLAIN
+    };
+
+    OutputResult result;
+    OutputError err = output_create(&req, &result);
+
+    ASSERT_EQ(err, OUTPUT_OK);
+    ASSERT_STR_CONTAINS(result.filepath, ".txt");
+}
+
+TEST(create_json_output) {
+    OutputRequest req = {
+        .title = "JSON Output",
+        .content = "{\"key\": \"value\"}",
+        .format = OUTPUT_FORMAT_JSON
+    };
+
+    OutputResult result;
+    OutputError err = output_create(&req, &result);
+
+    ASSERT_EQ(err, OUTPUT_OK);
+    ASSERT_STR_CONTAINS(result.filepath, ".json");
+}
+
+TEST(append_to_document) {
+    OutputRequest req = {
+        .title = "Append Test",
+        .content = "Initial content.",
+        .format = OUTPUT_FORMAT_MARKDOWN
+    };
+
+    OutputResult result;
+    output_create(&req, &result);
+
+    // Append
+    OutputError err = output_append(result.filepath, "\n\n## New Section\n\nAppended content.");
+    ASSERT_EQ(err, OUTPUT_OK);
+
+    char* content = read_file(result.filepath);
+    ASSERT(content != NULL);
+    ASSERT_STR_CONTAINS(content, "Initial content");
+    ASSERT_STR_CONTAINS(content, "New Section");
+    ASSERT_STR_CONTAINS(content, "Appended content");
+    free(content);
+}
+
+// ============================================================================
+// TEMPLATE TESTS
+// ============================================================================
+
+TEST(create_from_template_analysis) {
+    OutputResult result;
+    OutputError err = output_from_template("analysis", "Security Analysis", NULL, &result);
+
+    ASSERT_EQ(err, OUTPUT_OK);
+    ASSERT(result.success);
+
+    char* content = read_file(result.filepath);
+    ASSERT(content != NULL);
+    ASSERT_STR_CONTAINS(content, "Executive Summary");
+    ASSERT_STR_CONTAINS(content, "Key Findings");
+    ASSERT_STR_CONTAINS(content, "Recommendations");
+    free(content);
+}
+
+TEST(create_from_template_architecture) {
+    OutputResult result;
+    OutputError err = output_from_template("architecture", "System Architecture", NULL, &result);
+
+    ASSERT_EQ(err, OUTPUT_OK);
+
+    char* content = read_file(result.filepath);
+    ASSERT(content != NULL);
+    ASSERT_STR_CONTAINS(content, "Overview");
+    ASSERT_STR_CONTAINS(content, "Components");
+    ASSERT_STR_CONTAINS(content, "mermaid");
+    ASSERT_STR_CONTAINS(content, "flowchart");
+    free(content);
+}
+
+// ============================================================================
+// MERMAID TESTS
+// ============================================================================
+
+TEST(mermaid_block) {
+    MermaidDiagram diagram = {
+        .type = MERMAID_FLOWCHART,
+        .title = "Test Flow",
+        .content = "A --> B\nB --> C"
+    };
+
+    char* block = output_mermaid_block(&diagram);
+    ASSERT(block != NULL);
+    ASSERT_STR_CONTAINS(block, "```mermaid");
+    ASSERT_STR_CONTAINS(block, "flowchart TD");
+    ASSERT_STR_CONTAINS(block, "A --> B");
+    ASSERT_STR_CONTAINS(block, "```");
+    free(block);
+}
+
+TEST(mermaid_flowchart) {
+    const char* nodes[] = {"A[Start]", "B{Decision}", "C[End]", NULL};
+    const char* edges[] = {"A --> B", "B -->|Yes| C", "B -->|No| A", NULL};
+
+    char* diagram = output_mermaid_flowchart("My Flowchart", "TD", nodes, edges);
+    ASSERT(diagram != NULL);
+    ASSERT_STR_CONTAINS(diagram, "flowchart TD");
+    ASSERT_STR_CONTAINS(diagram, "A[Start]");
+    ASSERT_STR_CONTAINS(diagram, "B{Decision}");
+    ASSERT_STR_CONTAINS(diagram, "A --> B");
+    free(diagram);
+}
+
+TEST(mermaid_sequence) {
+    const char* participants[] = {"Client", "Server", "Database", NULL};
+    const char* messages[] = {
+        "Client->>Server: Request",
+        "Server->>Database: Query",
+        "Database-->>Server: Results",
+        "Server-->>Client: Response",
+        NULL
+    };
+
+    char* diagram = output_mermaid_sequence("API Flow", participants, messages);
+    ASSERT(diagram != NULL);
+    ASSERT_STR_CONTAINS(diagram, "sequenceDiagram");
+    ASSERT_STR_CONTAINS(diagram, "participant Client");
+    ASSERT_STR_CONTAINS(diagram, "Client->>Server");
+    free(diagram);
+}
+
+TEST(mermaid_gantt) {
+    const char* tasks[] = {
+        "Design :done, design, 2024-01-01, 7d",
+        "Development :active, dev, after design, 14d",
+        "Testing :test, after dev, 7d",
+        NULL
+    };
+
+    char* diagram = output_mermaid_gantt("Project Timeline", NULL, tasks);
+    ASSERT(diagram != NULL);
+    ASSERT_STR_CONTAINS(diagram, "gantt");
+    ASSERT_STR_CONTAINS(diagram, "Project Timeline");
+    ASSERT_STR_CONTAINS(diagram, "Design");
+    free(diagram);
+}
+
+TEST(mermaid_pie) {
+    const char* labels[] = {"Category A", "Category B", "Category C"};
+    const char* values[] = {"30", "45", "25"};
+
+    char* diagram = output_mermaid_pie("Distribution", labels, values, 3);
+    ASSERT(diagram != NULL);
+    ASSERT_STR_CONTAINS(diagram, "pie");
+    ASSERT_STR_CONTAINS(diagram, "Category A");
+    ASSERT_STR_CONTAINS(diagram, "30");
+    free(diagram);
+}
+
+TEST(mermaid_mindmap) {
+    char* diagram = output_mermaid_mindmap("Central Topic",
+        "    Branch1\n"
+        "      Leaf1\n"
+        "      Leaf2\n"
+        "    Branch2\n"
+        "      Leaf3\n");
+
+    ASSERT(diagram != NULL);
+    ASSERT_STR_CONTAINS(diagram, "mindmap");
+    ASSERT_STR_CONTAINS(diagram, "Central Topic");
+    ASSERT_STR_CONTAINS(diagram, "Branch1");
+    free(diagram);
+}
+
+// ============================================================================
+// TABLE TESTS
+// ============================================================================
+
+TEST(generate_simple_table) {
+    const char* headers[] = {"Name", "Age", "City"};
+    const char* row1[] = {"Alice", "30", "NYC"};
+    const char* row2[] = {"Bob", "25", "LA"};
+    const char** rows[] = {row1, row2, NULL};
+
+    char* table = output_table_simple(headers, 3, (const char***)rows, 2);
+    ASSERT(table != NULL);
+    ASSERT_STR_CONTAINS(table, "| Name |");
+    ASSERT_STR_CONTAINS(table, "| Alice |");
+    ASSERT_STR_CONTAINS(table, "| Bob |");
+    ASSERT_STR_CONTAINS(table, "---"); // Separator
+    free(table);
+}
+
+TEST(generate_aligned_table) {
+    TableColumn columns[] = {
+        {.header = "Left", .align = 'l'},
+        {.header = "Center", .align = 'c'},
+        {.header = "Right", .align = 'r'}
+    };
+
+    const char* row1[] = {"A", "B", "C"};
+    const char** rows[] = {row1, NULL};
+
+    char* table = output_table(columns, 3, (const char***)rows, 1);
+    ASSERT(table != NULL);
+    ASSERT_STR_CONTAINS(table, ":---"); // Left align
+    ASSERT_STR_CONTAINS(table, ":---:"); // Center align
+    ASSERT_STR_CONTAINS(table, "---:"); // Right align
+    free(table);
+}
+
+// ============================================================================
+// TERMINAL LINK TESTS
+// ============================================================================
+
+TEST(get_link) {
+    char* link = output_get_link("/tmp/test.md", "Test File");
+    ASSERT(link != NULL);
+    // Link should contain the path or the label
+    // (format depends on terminal support)
+    ASSERT(strlen(link) > 0);
+    free(link);
+}
+
+// ============================================================================
+// FILE MANAGEMENT TESTS
+// ============================================================================
+
+TEST(get_latest) {
+    // Create a document
+    OutputRequest req = {
+        .title = "Latest Test",
+        .content = "Content",
+        .format = OUTPUT_FORMAT_MARKDOWN
+    };
+    OutputResult created;
+    output_create(&req, &created);
+
+    // Get latest
+    OutputResult latest;
+    OutputError err = output_get_latest(&latest);
+    ASSERT_EQ(err, OUTPUT_OK);
+    ASSERT(latest.success);
+    ASSERT(strlen(latest.filepath) > 0);
+}
+
+TEST(list_recent) {
+    // Create multiple documents
+    for (int i = 0; i < 3; i++) {
+        char title[32];
+        snprintf(title, sizeof(title), "Doc %d", i);
+        OutputRequest req = {
+            .title = title,
+            .content = "Content",
+            .format = OUTPUT_FORMAT_MARKDOWN
+        };
+        OutputResult result;
+        output_create(&req, &result);
+    }
+
+    // List recent
+    char* paths[10] = {0};
+    int count = 0;
+    OutputError err = output_list_recent(10, paths, &count);
+    ASSERT_EQ(err, OUTPUT_OK);
+    ASSERT(count >= 1); // At least the date directory
+
+    for (int i = 0; i < count; i++) {
+        free(paths[i]);
+    }
+}
+
+TEST(delete_output) {
+    OutputRequest req = {
+        .title = "Delete Me",
+        .content = "To be deleted",
+        .format = OUTPUT_FORMAT_MARKDOWN
+    };
+    OutputResult result;
+    output_create(&req, &result);
+
+    // Verify exists
+    struct stat st;
+    ASSERT_EQ(stat(result.filepath, &st), 0);
+
+    // Delete
+    OutputError err = output_delete(result.filepath);
+    ASSERT_EQ(err, OUTPUT_OK);
+
+    // Verify gone
+    ASSERT_NE(stat(result.filepath, &st), 0);
+}
+
+TEST(get_total_size) {
+    OutputRequest req = {
+        .title = "Size Test",
+        .content = "Some content for size calculation.",
+        .format = OUTPUT_FORMAT_MARKDOWN
+    };
+    OutputResult result;
+    output_create(&req, &result);
+
+    size_t size = output_get_total_size();
+    ASSERT(size > 0);
+}
+
+// ============================================================================
+// INTEGRATION TEST
+// ============================================================================
+
+TEST(full_document_with_mermaid_and_table) {
+    // Create a document with everything
+    const char* nodes[] = {"A[Input]", "B[Process]", "C[Output]", NULL};
+    const char* edges[] = {"A --> B", "B --> C", NULL};
+    char* flowchart = output_mermaid_flowchart("Data Flow", "LR", nodes, edges);
+
+    const char* headers[] = {"Step", "Description", "Status"};
+    const char* row1[] = {"1", "Initialize", "Done"};
+    const char* row2[] = {"2", "Process", "Active"};
+    const char* row3[] = {"3", "Finalize", "Pending"};
+    const char** rows[] = {row1, row2, row3, NULL};
+    char* table = output_table_simple(headers, 3, (const char***)rows, 3);
+
+    // Build full content
+    size_t content_len = strlen(flowchart) + strlen(table) + 256;
+    char* content = malloc(content_len);
+    snprintf(content, content_len,
+        "## Overview\n\n"
+        "This document demonstrates all features.\n\n"
+        "## Diagram\n\n"
+        "```mermaid\n%s```\n\n"
+        "## Data\n\n"
+        "%s\n"
+        "## Conclusion\n\n"
+        "Everything works!\n",
+        flowchart, table);
+
+    OutputRequest req = {
+        .title = "Complete Integration Test",
+        .content = content,
+        .agent_name = "test-agent",
+        .project_context = "IntegrationTests",
+        .format = OUTPUT_FORMAT_MARKDOWN,
+        .include_timestamp = true
+    };
+
+    OutputResult result;
+    OutputError err = output_create(&req, &result);
+
+    ASSERT_EQ(err, OUTPUT_OK);
+    ASSERT(result.success);
+
+    // Read and verify
+    char* file_content = read_file(result.filepath);
+    ASSERT(file_content != NULL);
+    ASSERT_STR_CONTAINS(file_content, "Complete Integration Test");
+    ASSERT_STR_CONTAINS(file_content, "mermaid");
+    ASSERT_STR_CONTAINS(file_content, "flowchart");
+    ASSERT_STR_CONTAINS(file_content, "| Step |");
+    ASSERT_STR_CONTAINS(file_content, "test-agent");
+
+    free(file_content);
+    free(content);
+    free(flowchart);
+    free(table);
+
+    printf("\n    Created: %s", result.filepath);
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+int main(int argc, char** argv) {
+    printf("\n=== Convergio Output Service Tests ===\n\n");
+
+    printf("[INITIALIZATION]\n");
+    setup();
+    RUN_TEST(init_service);
+    teardown();
+
+    printf("\n[DOCUMENT CREATION]\n");
+    setup();
+    RUN_TEST(create_simple_document);
+    RUN_TEST(create_document_with_agent);
+    RUN_TEST(create_document_with_project_context);
+    RUN_TEST(create_plain_text);
+    RUN_TEST(create_json_output);
+    RUN_TEST(append_to_document);
+    teardown();
+
+    printf("\n[TEMPLATES]\n");
+    setup();
+    RUN_TEST(create_from_template_analysis);
+    RUN_TEST(create_from_template_architecture);
+    teardown();
+
+    printf("\n[MERMAID DIAGRAMS]\n");
+    setup();
+    RUN_TEST(mermaid_block);
+    RUN_TEST(mermaid_flowchart);
+    RUN_TEST(mermaid_sequence);
+    RUN_TEST(mermaid_gantt);
+    RUN_TEST(mermaid_pie);
+    RUN_TEST(mermaid_mindmap);
+    teardown();
+
+    printf("\n[TABLES]\n");
+    setup();
+    RUN_TEST(generate_simple_table);
+    RUN_TEST(generate_aligned_table);
+    teardown();
+
+    printf("\n[TERMINAL LINKS]\n");
+    setup();
+    RUN_TEST(get_link);
+    teardown();
+
+    printf("\n[FILE MANAGEMENT]\n");
+    setup();
+    RUN_TEST(get_latest);
+    RUN_TEST(list_recent);
+    RUN_TEST(delete_output);
+    RUN_TEST(get_total_size);
+    teardown();
+
+    printf("\n[INTEGRATION]\n");
+    setup();
+    RUN_TEST(full_document_with_mermaid_and_table);
+    teardown();
+
+    printf("\n\n=== All Output Service Tests Passed! ===\n\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Adds centralized output service for structured document generation
- Implements Mermaid diagram integration (flowcharts, sequence, gantt, pie, mindmap)
- Adds `convergio output` CLI command with list/open/delete/cleanup subcommands
- Uses OSC8 terminal hyperlinks for clickable file paths

## Changes

- `src/tools/output_service.c` - Main implementation (~650 LOC)
- `include/nous/output_service.h` - Public API
- `tests/test_output_service.c` - Unit tests (20+ cases)
- `docs/adr/012-output-service.md` - Architecture decision record
- `src/core/main.c` - Init/shutdown integration
- `src/core/commands/commands.c` - CLI command implementation
- `Makefile` - Build targets

## Test plan

- [x] Unit tests pass (`make output_service_test`)
- [x] Full build succeeds
- [x] Documentation check passes
- [x] Command help displays correctly

**Note**: This PR supersedes #61 which had complex merge conflicts after #60 was merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)