### PR TITLE
feat(editions): Runtime edition switching (R01-R06)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,24 @@
 # Version management
 VERSION := $(shell cat VERSION 2>/dev/null || echo "0.0.0")
 
+# Edition support (master, education, business, developer)
+# Usage: make EDITION=education
+EDITION ?= master
+
+ifeq ($(EDITION),education)
+    EDITION_CFLAGS = -DCONVERGIO_EDITION_EDUCATION
+    EDITION_SUFFIX = -edu
+else ifeq ($(EDITION),business)
+    EDITION_CFLAGS = -DCONVERGIO_EDITION_BUSINESS
+    EDITION_SUFFIX = -biz
+else ifeq ($(EDITION),developer)
+    EDITION_CFLAGS = -DCONVERGIO_EDITION_DEVELOPER
+    EDITION_SUFFIX = -dev
+else
+    EDITION_CFLAGS =
+    EDITION_SUFFIX =
+endif
+
 # Compiler settings
 CC = clang
 OBJC = clang
@@ -27,7 +45,8 @@ CFLAGS = $(ARCH_FLAGS) \
          -I./include \
          -I/opt/homebrew/include \
          -I$(READLINE_PREFIX)/include \
-         -DCONVERGIO_VERSION=\"$(VERSION)\"
+         -DCONVERGIO_VERSION=\"$(VERSION)\" \
+         $(EDITION_CFLAGS)
 
 OBJCFLAGS = $(CFLAGS) -fobjc-arc
 
@@ -98,6 +117,7 @@ C_SOURCES = $(SRC_DIR)/core/fabric.c \
             $(SRC_DIR)/core/stream_md.c \
             $(SRC_DIR)/core/theme.c \
             $(SRC_DIR)/core/config.c \
+            $(SRC_DIR)/core/edition.c \
             $(SRC_DIR)/core/updater.c \
             $(SRC_DIR)/core/safe_path.c \
             $(SRC_DIR)/intent/parser.c \
@@ -174,8 +194,8 @@ OBJECTS = $(C_OBJECTS) $(OBJC_OBJECTS)
 METAL_AIR = $(BUILD_DIR)/similarity.air
 METAL_LIB = $(BUILD_DIR)/similarity.metallib
 
-# Target
-TARGET = $(BIN_DIR)/convergio
+# Target (with edition suffix)
+TARGET = $(BIN_DIR)/convergio$(EDITION_SUFFIX)
 
 # Notification helper app
 NOTIFY_HELPER_SRC = $(SRC_DIR)/notifications/helper/main.swift

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,22 @@ VERSION := $(shell cat VERSION 2>/dev/null || echo "0.0.0")
 
 # Edition support (master, education, business, developer)
 # Usage: make EDITION=education
+#
+# Only Education uses compile-time locking (for child safety).
+# Other editions use runtime switching via --edition flag.
 EDITION ?= master
 
 ifeq ($(EDITION),education)
+    # Education edition is compile-time locked for child safety
     EDITION_CFLAGS = -DCONVERGIO_EDITION_EDUCATION
     EDITION_SUFFIX = -edu
 else ifeq ($(EDITION),business)
-    EDITION_CFLAGS = -DCONVERGIO_EDITION_BUSINESS
+    # Business edition - same binary as master, just different default
+    EDITION_CFLAGS =
     EDITION_SUFFIX = -biz
 else ifeq ($(EDITION),developer)
-    EDITION_CFLAGS = -DCONVERGIO_EDITION_DEVELOPER
+    # Developer edition - same binary as master, just different default
+    EDITION_CFLAGS =
     EDITION_SUFFIX = -dev
 else
     EDITION_CFLAGS =

--- a/README.md
+++ b/README.md
@@ -437,6 +437,46 @@ API keys can be configured via:
 
 ---
 
+## Editions
+
+Convergio is available in multiple editions, each focused on specific use cases:
+
+| Edition | Agents | Target Audience | Installation |
+|---------|--------|-----------------|--------------|
+| **Master** | 60+ | Developers, power users | `brew install convergio` |
+| **Education** | 18 | Students, teachers | `brew install convergio-edu` |
+| **Business** | 10 | SMBs, sales teams | `--edition business` |
+| **Developer** | 10 | DevOps, tech leads | `--edition developer` |
+
+### Switching Editions at Runtime
+
+```bash
+# Via CLI flag
+convergio --edition business
+
+# Via environment variable
+export CONVERGIO_EDITION=developer
+convergio
+
+# Via config.toml
+# Add to ~/.convergio/config.toml:
+# [ui]
+# edition = "business"
+```
+
+**Note:** Education edition requires a dedicated binary (`convergio-edu`) for child safety compliance. It cannot be switched at runtime.
+
+### Building Specific Editions
+
+```bash
+make                      # Master (default)
+make EDITION=education    # Education (outputs convergio-edu)
+make EDITION=business     # Business (outputs convergio-biz)
+make EDITION=developer    # Developer (outputs convergio-dev)
+```
+
+---
+
 ## Commands Reference
 
 ### Core Commands

--- a/README.md
+++ b/README.md
@@ -464,7 +464,9 @@ convergio
 # edition = "business"
 ```
 
-**Note:** Education edition requires a dedicated binary (`convergio-edu`) for child safety compliance. It cannot be switched at runtime.
+**Note:**
+- Edition switching requires restarting Convergio to take effect
+- Education edition requires a dedicated binary (`convergio-edu`) for child safety compliance
 
 ### Building Specific Editions
 

--- a/README.md
+++ b/README.md
@@ -465,7 +465,8 @@ convergio
 ```
 
 **Note:**
-- Edition switching requires restarting Convergio to take effect
+- Edition is set at startup and takes effect immediately for that session
+- To change edition, start a new Convergio session with the desired flag/config
 - Education edition requires a dedicated binary (`convergio-edu`) for child safety compliance
 
 ### Building Specific Editions

--- a/docs/RoadmapEditions.md
+++ b/docs/RoadmapEditions.md
@@ -1,0 +1,150 @@
+# Convergio Editions Roadmap
+
+**Created**: 2025-12-21
+**Status**: Active Discussion
+**Branch**: `feature/runtime-edition-switching`
+
+---
+
+## Current State (v5.3.1)
+
+### Edition System
+- **Runtime switching** for Master/Business/Developer via CLI, env var, or config
+- **Compile-time locking** for Education edition (child safety)
+- Priority: CLI flag > CONVERGIO_EDITION env var > config.toml
+- PR #73 implements this system
+
+### Editions Available
+| Edition | Binary | Use Case |
+|---------|--------|----------|
+| Master | `convergio` | All 60+ agents (default) |
+| Education | `convergio-edu` | 14 historical Maestri + accessibility |
+| Business | `convergio` | Sales, marketing, finance agents |
+| Developer | `convergio` | Code review, DevOps, security agents |
+
+---
+
+## Open Discussion: Multi-Repository Architecture
+
+### The Challenge
+As editions grow (more verticals like Education, Healthcare, Legal), maintaining everything in a single repository becomes complex:
+- Contributors who only care about one vertical must understand the whole codebase
+- Dependency updates affect all editions
+- Release cycles are coupled
+- Testing overhead grows
+
+### Proposed Solution: Core + Plugins
+
+```
+convergio-cli/                    # Core kernel (main repo)
+├── src/core/                     # Orchestrator, config, CLI
+├── src/providers/                # API providers
+├── src/agentic/                  # Tool system
+└── plugin-api/                   # Plugin interface for editions
+
+convergio-education/              # Education plugin repo
+├── agents/                       # 14 Maestri definitions
+├── features/                     # Quiz, flashcards, study sessions
+└── curricula/                    # Italian, UK, US curricula
+
+convergio-business/               # Business plugin repo
+├── agents/                       # Business agents
+└── features/                     # CRM, pipeline, analytics
+
+convergio-developer/              # Developer plugin repo
+├── agents/                       # Code review, security agents
+└── features/                     # Git, PR, test integrations
+```
+
+### Benefits
+1. **Focused contributions**: Contributors can work on single verticals
+2. **Independent release cycles**: Education can release without affecting core
+3. **Reduced dependencies**: Each plugin only has what it needs
+4. **Simpler testing**: Test one vertical at a time
+5. **Clearer ownership**: Different teams can own different plugins
+
+### Technical Requirements
+
+#### Plugin API Design
+```c
+// plugin-api/convergio_plugin.h
+typedef struct {
+    const char *id;              // "education", "business"
+    const char *version;
+    const char **agents;         // NULL-terminated list
+    const char **features;
+    const char **commands;
+
+    // Callbacks
+    int (*init)(void);
+    int (*shutdown)(void);
+    int (*on_agent_switch)(const char *agent_id);
+} ConvergioPlugin;
+
+// Core discovers plugins in ~/.convergio/plugins/
+int convergio_load_plugins(void);
+```
+
+#### Distribution Options
+1. **Homebrew formulas**: `brew install convergio-education`
+2. **Built-in plugin manager**: `convergio plugin install education`
+3. **Compile-time bundling**: Still needed for Education (child safety)
+
+### Migration Path
+1. **Phase 1** (Current): Single repo with edition system
+2. **Phase 2**: Extract plugin API, keep editions internal
+3. **Phase 3**: Move Education to separate repo (still compile-time)
+4. **Phase 4**: Move Business/Developer to plugins (runtime-loadable)
+
+---
+
+## Pending Features
+
+### Localization (Phase 13)
+- [ ] Multi-language support for UI strings
+- [ ] Education Maestri speak student's language
+- [ ] RTL support for Arabic/Hebrew
+
+### Hot-Reload (Deferred)
+- Hot-reload agent registry on edition switch
+- Currently requires restart (acceptable per user feedback)
+
+### Education-Specific
+- [ ] 14 Maestri with full personality
+- [ ] Accessibility profiles (dyslexia, ADHD, etc.)
+- [ ] Curriculum engine (Italian school system)
+- [ ] Quiz and study session system
+- [ ] Anna reminder integration
+
+---
+
+## Architecture Decision
+
+**ADR-003 Decision**: Education edition MUST remain compile-time locked.
+- Reason: Child safety compliance for schools
+- Parents/schools can trust the binary is "locked"
+- Cannot be circumvented by environment variables or config
+
+---
+
+## Questions to Resolve
+
+1. **Plugin discovery**: ~/.convergio/plugins/ or bundled?
+2. **Version compatibility**: How to ensure plugin works with core version?
+3. **Feature flags**: Should features be plugin-level or global?
+4. **Agent override**: Can plugins override core agents?
+
+---
+
+## Next Steps
+
+1. Merge PR #73 (runtime edition switching)
+2. Merge `feature/education-pack` into main
+3. Design plugin API specification
+4. Create ADR for plugin architecture
+5. Prototype with Education as first plugin
+
+---
+
+**Last Updated**: 2025-12-21
+**Author**: Roberto with AI team support

--- a/include/nous/config.h
+++ b/include/nous/config.h
@@ -30,6 +30,7 @@ typedef struct {
     char debug_level[16];  // none, error, warn, info, debug, trace
     char theme[32];        // Theme name (Ocean, Forest, Sunset, etc.)
     char style[16];        // Response style: flash, concise, balanced, detailed
+    char edition[32];      // Edition: master, business, developer (education is compile-time only)
 
     // Updates
     bool check_updates_on_startup;

--- a/include/nous/edition.h
+++ b/include/nous/edition.h
@@ -78,6 +78,19 @@ bool edition_set(ConvergioEdition edition);
 bool edition_set_by_name(const char *name);
 
 /**
+ * Set edition by CLI flag (marks as CLI priority)
+ * Use this when parsing --edition command line argument
+ * CLI takes priority over env var and config
+ */
+bool edition_set_by_cli(const char *name);
+
+/**
+ * Check if edition was set via CLI flag
+ * Config and env var should skip setting if this returns true
+ */
+bool edition_was_set_by_cli(void);
+
+/**
  * Check if edition can be changed at runtime
  * Returns false for Education binary
  */

--- a/include/nous/edition.h
+++ b/include/nous/edition.h
@@ -1,0 +1,134 @@
+/**
+ * CONVERGIO KERNEL - EDITION SYSTEM
+ *
+ * Verticalization support for multiple Convergio editions.
+ * Each edition has specific agents, features, and branding.
+ *
+ * Runtime switching supported for Master/Business/Developer.
+ * Education edition is compile-time locked for child safety.
+ *
+ * Copyright (c) 2025 Convergio.io
+ * Licensed under Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+ */
+
+#ifndef NOUS_EDITION_H
+#define NOUS_EDITION_H
+
+#include <stdbool.h>
+
+// ============================================================================
+// EDITION TYPES
+// ============================================================================
+
+typedef enum {
+    EDITION_MASTER = 0,      // ALL agents - the complete Convergio experience
+    EDITION_EDUCATION = 1,   // Maestri + Education tools + Ali (compile-time only)
+    EDITION_BUSINESS = 2,    // Business agents + Ali
+    EDITION_DEVELOPER = 3    // Developer agents + Ali
+} ConvergioEdition;
+
+// Backwards compatibility
+#define EDITION_FULL EDITION_MASTER
+
+// ============================================================================
+// EDITION INFO
+// ============================================================================
+
+typedef struct {
+    ConvergioEdition id;
+    const char *name;           // "Convergio Education"
+    const char *short_name;     // "Education"
+    const char *version_suffix; // "-edu"
+    const char *description;
+    const char *target_audience;
+
+    // Agent whitelist (NULL-terminated array of agent IDs)
+    const char **allowed_agents;
+
+    // Feature whitelist (NULL-terminated array of feature IDs)
+    const char **allowed_features;
+
+    // CLI commands whitelist (NULL-terminated array)
+    const char **allowed_commands;
+
+} EditionInfo;
+
+// ============================================================================
+// PUBLIC API
+// ============================================================================
+
+/**
+ * Get current edition
+ */
+ConvergioEdition edition_current(void);
+
+/**
+ * Set edition at runtime
+ * Returns true on success, false if:
+ * - Edition is locked (Education binary)
+ * - Trying to switch TO Education (not allowed at runtime)
+ */
+bool edition_set(ConvergioEdition edition);
+
+/**
+ * Set edition by name string
+ * Valid names: "master", "business", "developer"
+ * Returns true on success, false on failure
+ */
+bool edition_set_by_name(const char *name);
+
+/**
+ * Check if edition can be changed at runtime
+ * Returns false for Education binary
+ */
+bool edition_is_mutable(void);
+
+/**
+ * Get edition info for current or specified edition
+ */
+const EditionInfo *edition_get_info(ConvergioEdition edition);
+const EditionInfo *edition_get_current_info(void);
+
+/**
+ * Check if agent is available in current edition
+ */
+bool edition_has_agent(const char *agent_id);
+
+/**
+ * Check if feature is available in current edition
+ */
+bool edition_has_feature(const char *feature_id);
+
+/**
+ * Check if command is available in current edition
+ */
+bool edition_has_command(const char *command);
+
+/**
+ * Get edition display name for UI
+ */
+const char *edition_display_name(void);
+
+/**
+ * Get edition-specific system prompt prefix
+ */
+const char *edition_system_prompt(void);
+
+/**
+ * Initialize edition system
+ * Call after config is loaded to apply saved edition
+ */
+void edition_init(void);
+
+/**
+ * Get edition name for config/display
+ */
+const char *edition_get_name(ConvergioEdition edition);
+
+/**
+ * Parse edition from name string
+ * Returns EDITION_MASTER if not recognized
+ */
+ConvergioEdition edition_from_name(const char *name);
+
+#endif /* NOUS_EDITION_H */

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -304,7 +304,8 @@ int convergio_config_save(void) {
     fprintf(f, "debug_level = \"%s\"\n", g_config.debug_level);
     fprintf(f, "theme = \"%s\"\n", g_config.theme[0] ? g_config.theme : "Ocean");
     fprintf(f, "style = \"%s\"\n", g_config.style[0] ? g_config.style : "balanced");
-    fprintf(f, "edition = \"%s\"\n\n", g_config.edition[0] ? g_config.edition : "master");
+    // Save current runtime edition (may differ from config if set via CLI/env)
+    fprintf(f, "edition = \"%s\"\n\n", edition_get_name(edition_current()));
 
     fprintf(f, "[updates]\n");
     fprintf(f, "check_on_startup = %s\n", g_config.check_updates_on_startup ? "true" : "false");

--- a/src/core/edition.c
+++ b/src/core/edition.c
@@ -1,0 +1,351 @@
+/**
+ * CONVERGIO KERNEL - EDITION SYSTEM
+ *
+ * Verticalization implementation for multiple Convergio editions.
+ * Supports runtime switching for Master/Business/Developer.
+ * Education edition is compile-time locked.
+ *
+ * Build with: make EDITION=education (or business, developer)
+ *
+ * Copyright (c) 2025 Convergio.io
+ * Licensed under Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+ */
+
+#include "nous/edition.h"
+#include <string.h>
+#include <stdio.h>
+
+// Version is passed as -DCONVERGIO_VERSION from Makefile
+#ifndef CONVERGIO_VERSION
+#define CONVERGIO_VERSION "0.0.0"
+#endif
+
+// ============================================================================
+// RUNTIME EDITION STATE
+// ============================================================================
+
+// Education binary is locked at compile time
+#ifdef CONVERGIO_EDITION_EDUCATION
+static const bool g_edition_locked = true;
+static ConvergioEdition g_current_edition = EDITION_EDUCATION;
+#else
+static const bool g_edition_locked = false;
+static ConvergioEdition g_current_edition = EDITION_MASTER;
+#endif
+
+// ============================================================================
+// EDUCATION EDITION WHITELIST
+// ============================================================================
+
+static const char *EDUCATION_AGENTS[] = {
+    // 15 Maestri (matching embedded agent filenames)
+    "euclide-matematica",
+    "feynman-fisica",
+    "manzoni-italiano",
+    "darwin-scienze",
+    "erodoto-storia",
+    "humboldt-geografia",
+    "leonardo-arte",
+    "shakespeare-inglese",
+    "mozart-musica",
+    "cicerone-civica",
+    "smith-economia",
+    "lovelace-informatica",
+    "ippocrate-corpo",
+    "socrate-filosofia",
+    "chris-storytelling",
+    // Coordination
+    "ali-principal",
+    "anna-executive-assistant",
+    "jenny-inclusive-accessibility-champion",
+    NULL
+};
+
+static const char *EDUCATION_FEATURES[] = {
+    "quiz", "flashcards", "mindmap", "study-session", "homework",
+    "libretto", "audio-tts", "html-interactive", "calculator",
+    "voice", "accessibility",
+    NULL
+};
+
+static const char *EDUCATION_COMMANDS[] = {
+    "education", "study", "homework", "quiz", "flashcards",
+    "mindmap", "libretto", "voice", "html", "calc",
+    "define", "conjugate", "pronounce", "grammar",
+    "xp", "video", "periodic", "convert",
+    "help", "agent", "agents", "status", "quit", "exit",
+    "setup", "debug", "theme", "style", "cost",
+    "todo", "remind", "reminders",
+    NULL
+};
+
+// ============================================================================
+// BUSINESS EDITION WHITELIST
+// ============================================================================
+
+static const char *BUSINESS_AGENTS[] = {
+    "ali-chief-of-staff",
+    "fabio-sales-business-development",
+    "andrea-customer-success-manager",
+    "sofia-marketing-strategist",
+    "anna-executive-assistant",
+    "fiona-market-analyst",
+    "matteo-strategic-business-architect",
+    "amy-cfo",
+    "michael-vc",
+    "wiz-investor-venture-capital",
+    NULL
+};
+
+static const char *BUSINESS_FEATURES[] = {
+    "crm", "pipeline", "analytics", "reports", "finance",
+    NULL
+};
+
+static const char *BUSINESS_COMMANDS[] = {
+    "help", "agent", "agents", "status", "quit", "exit",
+    "setup", "debug", "theme", "style", "cost",
+    "todo", "remind", "reminders",
+    NULL
+};
+
+// ============================================================================
+// DEVELOPER EDITION WHITELIST
+// ============================================================================
+
+static const char *DEVELOPER_AGENTS[] = {
+    "ali-chief-of-staff",
+    "anna-executive-assistant",
+    "rex-code-reviewer",
+    "paolo-best-practices-enforcer",
+    "baccio-tech-architect",
+    "dario-debugger",
+    "otto-performance-optimizer",
+    "marco-devops-engineer",
+    "luca-security-expert",
+    "guardian-ai-security-validator",
+    NULL
+};
+
+static const char *DEVELOPER_FEATURES[] = {
+    "code-review", "architecture", "debugging", "security",
+    "ci-cd", "performance", "best-practices",
+    NULL
+};
+
+static const char *DEVELOPER_COMMANDS[] = {
+    "help", "agent", "agents", "status", "quit", "exit",
+    "setup", "debug", "theme", "style", "cost",
+    "todo", "remind", "reminders",
+    "test", "git", "pr", "commit",
+    NULL
+};
+
+// ============================================================================
+// EDITION DEFINITIONS
+// ============================================================================
+
+static const EditionInfo EDITIONS[] = {
+    // EDITION_MASTER - all agents
+    {
+        .id = EDITION_MASTER,
+        .name = "Convergio",
+        .short_name = "Master",
+        .version_suffix = "",
+        .description = "Complete Convergio with all agents and features",
+        .target_audience = "Developers and power users",
+        .allowed_agents = NULL,  // NULL = all agents
+        .allowed_features = NULL,
+        .allowed_commands = NULL,
+    },
+    // EDITION_EDUCATION
+    {
+        .id = EDITION_EDUCATION,
+        .name = "Convergio Education",
+        .short_name = "Education",
+        .version_suffix = "-edu",
+        .description = "Virtual classroom with historical maestri",
+        .target_audience = "Students 6-19, parents, teachers",
+        .allowed_agents = EDUCATION_AGENTS,
+        .allowed_features = EDUCATION_FEATURES,
+        .allowed_commands = EDUCATION_COMMANDS,
+    },
+    // EDITION_BUSINESS
+    {
+        .id = EDITION_BUSINESS,
+        .name = "Convergio Business",
+        .short_name = "Business",
+        .version_suffix = "-biz",
+        .description = "Business productivity and sales tools",
+        .target_audience = "SMBs, startups, sales teams",
+        .allowed_agents = BUSINESS_AGENTS,
+        .allowed_features = BUSINESS_FEATURES,
+        .allowed_commands = BUSINESS_COMMANDS,
+    },
+    // EDITION_DEVELOPER
+    {
+        .id = EDITION_DEVELOPER,
+        .name = "Convergio Developer",
+        .short_name = "Developer",
+        .version_suffix = "-dev",
+        .description = "Code review, architecture, and DevOps tools",
+        .target_audience = "Developers, DevOps, Tech Leads",
+        .allowed_agents = DEVELOPER_AGENTS,
+        .allowed_features = DEVELOPER_FEATURES,
+        .allowed_commands = DEVELOPER_COMMANDS,
+    },
+};
+
+// ============================================================================
+// SYSTEM PROMPTS PER EDITION
+// ============================================================================
+
+static const char *EDUCATION_SYSTEM_PROMPT =
+    "You are part of Convergio Education, a virtual classroom with the greatest "
+    "teachers in history. Your role is to help students learn through the Socratic "
+    "method, encouraging curiosity and understanding rather than just giving answers. "
+    "Always adapt to the student's level and accessibility needs.";
+
+static const char *BUSINESS_SYSTEM_PROMPT =
+    "You are part of Convergio Business, a professional productivity suite. "
+    "Focus on actionable insights, data-driven decisions, and business outcomes. "
+    "Be concise and professional.";
+
+static const char *DEVELOPER_SYSTEM_PROMPT =
+    "You are part of Convergio Developer, a code assistant for professional developers. "
+    "Focus on code quality, best practices, and architectural decisions. "
+    "Be precise and technical.";
+
+// ============================================================================
+// PUBLIC API IMPLEMENTATION
+// ============================================================================
+
+ConvergioEdition edition_current(void) {
+    return g_current_edition;
+}
+
+bool edition_is_mutable(void) {
+    return !g_edition_locked;
+}
+
+bool edition_set(ConvergioEdition edition) {
+    // Education binary cannot change edition
+    if (g_edition_locked) {
+        fprintf(stderr, "[Edition] Cannot change edition: binary is locked to Education\n");
+        return false;
+    }
+
+    // Cannot switch TO education at runtime (security)
+    if (edition == EDITION_EDUCATION) {
+        fprintf(stderr, "[Edition] Cannot switch to Education at runtime\n");
+        return false;
+    }
+
+    // Validate edition
+    if (edition < EDITION_MASTER || edition > EDITION_DEVELOPER) {
+        fprintf(stderr, "[Edition] Invalid edition: %d\n", edition);
+        return false;
+    }
+
+    // No change needed
+    if (edition == g_current_edition) {
+        return true;
+    }
+
+    g_current_edition = edition;
+    fprintf(stderr, "[Edition] Switched to %s\n", EDITIONS[edition].name);
+    return true;
+}
+
+bool edition_set_by_name(const char *name) {
+    if (!name) return false;
+    return edition_set(edition_from_name(name));
+}
+
+ConvergioEdition edition_from_name(const char *name) {
+    if (!name) return EDITION_MASTER;
+
+    if (strcmp(name, "master") == 0 || strcmp(name, "full") == 0) {
+        return EDITION_MASTER;
+    } else if (strcmp(name, "education") == 0 || strcmp(name, "edu") == 0) {
+        return EDITION_EDUCATION;
+    } else if (strcmp(name, "business") == 0 || strcmp(name, "biz") == 0) {
+        return EDITION_BUSINESS;
+    } else if (strcmp(name, "developer") == 0 || strcmp(name, "dev") == 0) {
+        return EDITION_DEVELOPER;
+    }
+
+    return EDITION_MASTER;
+}
+
+const char *edition_get_name(ConvergioEdition edition) {
+    switch (edition) {
+        case EDITION_MASTER: return "master";
+        case EDITION_EDUCATION: return "education";
+        case EDITION_BUSINESS: return "business";
+        case EDITION_DEVELOPER: return "developer";
+        default: return "master";
+    }
+}
+
+const EditionInfo *edition_get_info(ConvergioEdition edition) {
+    if (edition >= 0 && edition <= EDITION_DEVELOPER) {
+        return &EDITIONS[edition];
+    }
+    return &EDITIONS[EDITION_MASTER];
+}
+
+const EditionInfo *edition_get_current_info(void) {
+    return edition_get_info(g_current_edition);
+}
+
+static bool string_in_list(const char *str, const char **list) {
+    if (!str || !list) return true;  // NULL list = allow all
+
+    for (const char **p = list; *p != NULL; p++) {
+        if (strcmp(str, *p) == 0) return true;
+    }
+    return false;
+}
+
+bool edition_has_agent(const char *agent_id) {
+    const EditionInfo *info = edition_get_current_info();
+    return string_in_list(agent_id, info->allowed_agents);
+}
+
+bool edition_has_feature(const char *feature_id) {
+    const EditionInfo *info = edition_get_current_info();
+    return string_in_list(feature_id, info->allowed_features);
+}
+
+bool edition_has_command(const char *command) {
+    const EditionInfo *info = edition_get_current_info();
+    return string_in_list(command, info->allowed_commands);
+}
+
+const char *edition_display_name(void) {
+    return edition_get_current_info()->name;
+}
+
+const char *edition_system_prompt(void) {
+    switch (g_current_edition) {
+        case EDITION_EDUCATION:
+            return EDUCATION_SYSTEM_PROMPT;
+        case EDITION_BUSINESS:
+            return BUSINESS_SYSTEM_PROMPT;
+        case EDITION_DEVELOPER:
+            return DEVELOPER_SYSTEM_PROMPT;
+        default:
+            return "";
+    }
+}
+
+void edition_init(void) {
+    const EditionInfo *info = edition_get_current_info();
+    if (g_current_edition != EDITION_MASTER) {
+        fprintf(stderr, "[Edition] %s v%s%s\n",
+                info->name,
+                CONVERGIO_VERSION,
+                info->version_suffix);
+    }
+}

--- a/src/core/edition.c
+++ b/src/core/edition.c
@@ -1,9 +1,9 @@
 /**
  * CONVERGIO KERNEL - EDITION SYSTEM
  *
- * Verticalization implementation for multiple Convergio editions.
- * Supports runtime switching for Master/Business/Developer.
- * Education edition is compile-time locked.
+ * Implements verticalization for multiple Convergio editions.
+ * Supports runtime switching between Master, Business, and Developer editions.
+ * Education edition is compile-time locked for child safety.
  *
  * Build with: make EDITION=education (or business, developer)
  *

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -11,6 +11,7 @@
 #include "nous/orchestrator.h"
 #include "nous/tools.h"
 #include "nous/config.h"
+#include "nous/edition.h"
 #include "nous/hardware.h"
 #include "nous/updater.h"
 #include "nous/theme.h"
@@ -264,6 +265,14 @@ int main(int argc, char** argv) {
         } else if ((strcmp(argv[i], "--model") == 0 || strcmp(argv[i], "-m") == 0) && i + 1 < argc) {
             strncpy(g_mlx_model, argv[++i], sizeof(g_mlx_model) - 1);
             g_mlx_model[sizeof(g_mlx_model) - 1] = '\0';
+        } else if ((strcmp(argv[i], "--edition") == 0 || strcmp(argv[i], "-e") == 0) && i + 1 < argc) {
+            const char* ed = argv[++i];
+            if (!edition_set_by_name(ed)) {
+                fprintf(stderr, "Error: Cannot set edition to '%s'\n", ed);
+                fprintf(stderr, "Valid editions: master, business, developer\n");
+                fprintf(stderr, "(Education edition requires dedicated binary)\n");
+                return 1;
+            }
         } else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
             printf("Convergio — Human purpose. AI momentum.\n\n");
             printf("Usage: convergio [OPTIONS] [COMMAND]\n\n");
@@ -272,6 +281,7 @@ int main(int argc, char** argv) {
             printf("  update [check|install]  Check for or install updates\n\n");
             printf("Options:\n");
             printf("  -w, --workspace <path>  Set workspace directory (default: current dir)\n");
+            printf("  -e, --edition <name>    Set edition (master, business, developer)\n");
             printf("  -l, --local             Use MLX local models (Apple Silicon only)\n");
             printf("  -m, --model <model>     Specify model (e.g., llama-3.2-3b, deepseek-r1-7b)\n");
             printf("  -d, --debug             Enable debug logging\n");
@@ -279,6 +289,12 @@ int main(int argc, char** argv) {
             printf("  -q, --quiet             Suppress non-error output\n");
             printf("  -v, --version           Show version\n");
             printf("  -h, --help              Show this help message\n\n");
+            printf("Editions:\n");
+            printf("  master     All 60+ agents (default)\n");
+            printf("  business   Business, sales, marketing agents\n");
+            printf("  developer  Code review, DevOps, security agents\n");
+            printf("  education  Requires dedicated binary (convergio-edu)\n\n");
+            printf("  Can also set via CONVERGIO_EDITION env var or edition in config.toml\n\n");
             printf("Local Models (MLX):\n");
             printf("  Convergio supports 100%% offline operation using MLX on Apple Silicon.\n");
             printf("  Use /setup -> Local Models to download models, or:\n");

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -267,10 +267,10 @@ int main(int argc, char** argv) {
             g_mlx_model[sizeof(g_mlx_model) - 1] = '\0';
         } else if ((strcmp(argv[i], "--edition") == 0 || strcmp(argv[i], "-e") == 0) && i + 1 < argc) {
             const char* ed = argv[++i];
-            if (!edition_set_by_name(ed)) {
-                fprintf(stderr, "Error: Cannot set edition to '%s'\n", ed);
+            if (!edition_set_by_cli(ed)) {
+                // Error already printed by edition_set_by_cli
                 fprintf(stderr, "Valid editions: master, business, developer\n");
-                fprintf(stderr, "(Education edition requires dedicated binary)\n");
+                fprintf(stderr, "(Education edition requires dedicated binary: convergio-edu)\n");
                 return 1;
             }
         } else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
@@ -356,6 +356,9 @@ int main(int argc, char** argv) {
         fprintf(stderr, "  \033[31m✗ Config initialization failed\033[0m\n");
         init_errors = true;
     }
+
+    // Initialize edition system (displays edition info for non-master)
+    edition_init();
 
     // Initialize theme system
     theme_init();


### PR DESCRIPTION
## Summary
- Implements runtime edition switching for Master/Business/Developer editions
- Education edition remains compile-time locked for child safety
- Adds --edition CLI flag, CONVERGIO_EDITION env var, and config.toml support
- Priority: CLI > env var > config.toml
- Edition switch requires app restart (no hot-reload, per user decision)

## Changes
- `include/nous/edition.h` - Edition types and API
- `src/core/edition.c` - Runtime switching with Education lock
- `src/core/main.c` - CLI --edition flag
- `src/core/config.c` - Config and env var parsing
- `include/nous/config.h` - Edition field in config struct
- `Makefile` - EDITION= build support
- `README.md` - Documentation

## Test plan
- [ ] `make` builds Master edition
- [ ] `make EDITION=education` builds Education binary
- [ ] `./convergio --edition business` switches to Business
- [ ] `CONVERGIO_EDITION=developer ./convergio` uses Developer
- [ ] `convergio-edu --edition master` correctly rejects switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)