### PR TITLE
fix(build): Critical hotfix for duplicate symbol error in v6.0.0

### DIFF
--- a/src/education/mastery_gate.c
+++ b/src/education/mastery_gate.c
@@ -40,23 +40,8 @@ bool mastery_can_advance(int64_t student_id, const char* target_skill_id,
     return true; // All prerequisites mastered, can advance
 }
 
-/**
- * Get mastery level for a skill (0.0 - 1.0)
- */
-float mastery_get_level(int64_t student_id, const char* skill_id) {
-    if (!skill_id)
-        return 0.0f;
-    return education_mastery_get_level(student_id, skill_id);
-}
-
-/**
- * Check if skill is mastered (80%+)
- */
-bool mastery_is_mastered(int64_t student_id, const char* skill_id) {
-    if (!skill_id)
-        return false;
-    return education_mastery_is_mastered(student_id, skill_id);
-}
+// Note: mastery_get_level() is implemented in mastery.c
+// Note: mastery_is_mastered() - use education_mastery_is_mastered() directly
 
 /**
  * Get blocking message if student cannot advance


### PR DESCRIPTION
## Summary

- **Critical fix**: Removes duplicate `mastery_get_level` symbol that was causing build failures in v6.0.0
- The v6.0.0 release was shipped with a linker error that prevented the project from compiling

## Root Cause

Both `mastery.c` and `mastery_gate.c` defined `mastery_get_level()` function:
- `mastery.c:328` - The real implementation
- `mastery_gate.c:46` - A redundant wrapper

This caused:
```
duplicate symbol '_mastery_get_level' in:
    build/obj/education/mastery.o
    build/obj/education/mastery_gate.o
```

## Fix

Removed the duplicate wrapper functions from `mastery_gate.c`:
- `mastery_get_level()` (was just calling `education_mastery_get_level`)
- `mastery_is_mastered()` (was just calling `education_mastery_is_mastered`)

## Test plan

- [x] Build compiles successfully (`make clean && make`)
- [x] All tests pass (`make test`)
- [x] No linker errors

## After merge

This will be released as v6.0.1 hotfix to replace the broken v6.0.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)