### PR TITLE
feat(homebrew): Multi-edition Homebrew formulas

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,31 +267,55 @@ jobs:
             See [CHANGELOG.md](https://github.com/Roberdan/convergio-cli/blob/main/CHANGELOG.md) for details.
           generate_release_notes: true
 
-      # --- Update Homebrew Formula ---
-      - name: Update Homebrew Formula
+      # --- Update Homebrew Formulas (All Editions) ---
+      - name: Update Homebrew Formulas
         env:
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
         run: |
           VERSION=${{ steps.version.outputs.VERSION }}
-          SHA256=${{ steps.sha256.outputs.SHA256_MASTER }}
+          SHA256_MASTER=${{ steps.sha256.outputs.SHA256_MASTER }}
+          SHA256_EDU=${{ steps.sha256.outputs.SHA256_EDU }}
+          SHA256_BIZ=${{ steps.sha256.outputs.SHA256_BIZ }}
+          SHA256_DEV=${{ steps.sha256.outputs.SHA256_DEV }}
 
-          # Update formula in local copy first
+          # Update Master formula
           sed -i '' "s/version \".*\"/version \"${VERSION}\"/" Formula/convergio.rb
-          sed -i '' "s/sha256 \".*\"/sha256 \"${SHA256}\"/" Formula/convergio.rb
+          sed -i '' "s/sha256 \".*\"/sha256 \"${SHA256_MASTER}\"/" Formula/convergio.rb
           sed -i '' "s|/v[0-9]*\.[0-9]*\.[0-9]*/|/v${VERSION}/|g" Formula/convergio.rb
           sed -i '' "s/convergio-[0-9]*\.[0-9]*\.[0-9]*/convergio-${VERSION}/g" Formula/convergio.rb
 
-          # Update Homebrew tap repository (the only one used by brew)
+          # Update Education formula
+          sed -i '' "s/version \".*\"/version \"${VERSION}\"/" Formula/convergio-edu.rb
+          sed -i '' "s/sha256 \".*\"/sha256 \"${SHA256_EDU}\"/" Formula/convergio-edu.rb
+          sed -i '' "s|/v[0-9]*\.[0-9]*\.[0-9]*/|/v${VERSION}/|g" Formula/convergio-edu.rb
+          sed -i '' "s/convergio-edu-[0-9]*\.[0-9]*\.[0-9]*/convergio-edu-${VERSION}/g" Formula/convergio-edu.rb
+
+          # Update Business formula
+          sed -i '' "s/version \".*\"/version \"${VERSION}\"/" Formula/convergio-biz.rb
+          sed -i '' "s/sha256 \".*\"/sha256 \"${SHA256_BIZ}\"/" Formula/convergio-biz.rb
+          sed -i '' "s|/v[0-9]*\.[0-9]*\.[0-9]*/|/v${VERSION}/|g" Formula/convergio-biz.rb
+          sed -i '' "s/convergio-biz-[0-9]*\.[0-9]*\.[0-9]*/convergio-biz-${VERSION}/g" Formula/convergio-biz.rb
+
+          # Update Developer formula
+          sed -i '' "s/version \".*\"/version \"${VERSION}\"/" Formula/convergio-dev.rb
+          sed -i '' "s/sha256 \".*\"/sha256 \"${SHA256_DEV}\"/" Formula/convergio-dev.rb
+          sed -i '' "s|/v[0-9]*\.[0-9]*\.[0-9]*/|/v${VERSION}/|g" Formula/convergio-dev.rb
+          sed -i '' "s/convergio-dev-[0-9]*\.[0-9]*\.[0-9]*/convergio-dev-${VERSION}/g" Formula/convergio-dev.rb
+
+          # Update Homebrew tap repository with ALL formulas
           cd /tmp
           git clone https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/Roberdan/homebrew-convergio-cli.git tap-repo
           cp $GITHUB_WORKSPACE/Formula/convergio.rb tap-repo/Formula/
+          cp $GITHUB_WORKSPACE/Formula/convergio-edu.rb tap-repo/Formula/
+          cp $GITHUB_WORKSPACE/Formula/convergio-biz.rb tap-repo/Formula/
+          cp $GITHUB_WORKSPACE/Formula/convergio-dev.rb tap-repo/Formula/
           cd tap-repo
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          git add Formula/convergio.rb
-          git diff --staged --quiet || git commit -m "chore: Update formula to v${VERSION}"
+          git add Formula/
+          git diff --staged --quiet || git commit -m "chore: Update all formulas to v${VERSION}"
           git push origin main
-          echo "✅ Homebrew tap updated to v${VERSION}"
+          echo "✅ Homebrew tap updated to v${VERSION} (all 4 editions)"
 
       # --- Cleanup ---
       - name: Cleanup keychain

--- a/Formula/convergio-biz.rb
+++ b/Formula/convergio-biz.rb
@@ -1,0 +1,49 @@
+class ConvergioBiz < Formula
+  desc "Convergio Business Edition - AI agents for sales, marketing & strategy"
+  homepage "https://github.com/Roberdan/convergio-cli"
+  version "6.0.2"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/Roberdan/convergio-cli/releases/download/v6.0.2/convergio-biz-6.0.2-arm64-apple-darwin.tar.gz"
+      sha256 "b115ef3fce15013a14bab0627b6e37e3814d83199345f837a6923ed17bad7abb"
+    end
+  end
+
+  depends_on :macos
+  depends_on arch: :arm64
+
+  def install
+    bin.install "convergio-biz"
+  end
+
+  def caveats
+    <<~EOS
+      Convergio Business has been installed!
+
+      To get started, run:
+        convergio-biz setup
+
+      This will configure your Anthropic API key securely.
+
+      Features:
+        - 10 business-focused AI agents
+        - Sales & pipeline management (Fabio)
+        - Customer success (Andrea)
+        - Marketing strategy (Sofia)
+        - Market analysis (Fiona)
+        - Financial planning (Amy CFO)
+
+      Quick start:
+        convergio-biz              # Start interactive session
+        convergio-biz --help       # Show all options
+
+      Documentation: https://github.com/Roberdan/convergio-cli
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/convergio-biz --version")
+  end
+end

--- a/Formula/convergio-dev.rb
+++ b/Formula/convergio-dev.rb
@@ -1,0 +1,51 @@
+class ConvergioDev < Formula
+  desc "Convergio Developer Edition - AI agents for code review, DevOps & security"
+  homepage "https://github.com/Roberdan/convergio-cli"
+  version "6.0.2"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/Roberdan/convergio-cli/releases/download/v6.0.2/convergio-dev-6.0.2-arm64-apple-darwin.tar.gz"
+      sha256 "76e45bb7725fe663be594c06f18080ac0e4da429ace697653b804a3976d4a84b"
+    end
+  end
+
+  depends_on :macos
+  depends_on arch: :arm64
+
+  def install
+    bin.install "convergio-dev"
+  end
+
+  def caveats
+    <<~EOS
+      Convergio Developer has been installed!
+
+      To get started, run:
+        convergio-dev setup
+
+      This will configure your Anthropic API key securely.
+
+      Features:
+        - 11 developer-focused AI agents
+        - Code review (Rex)
+        - Best practices enforcement (Paolo)
+        - Architecture design (Baccio)
+        - Debugging assistance (Dario)
+        - Performance optimization (Otto)
+        - DevOps & CI/CD (Marco)
+        - Security analysis (Luca)
+
+      Quick start:
+        convergio-dev              # Start interactive session
+        convergio-dev --help       # Show all options
+
+      Documentation: https://github.com/Roberdan/convergio-cli
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/convergio-dev --version")
+  end
+end

--- a/Formula/convergio-edu.rb
+++ b/Formula/convergio-edu.rb
@@ -1,0 +1,47 @@
+class ConvergioEdu < Formula
+  desc "Convergio Education Edition - AI Maestri teachers for K-12 students"
+  homepage "https://github.com/Roberdan/convergio-cli"
+  version "6.0.2"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/Roberdan/convergio-cli/releases/download/v6.0.2/convergio-edu-6.0.2-arm64-apple-darwin.tar.gz"
+      sha256 "d820d4da87486e09de840261835e81df3ae840383acab460163e6ee7ad743b99"
+    end
+  end
+
+  depends_on :macos
+  depends_on arch: :arm64
+
+  def install
+    bin.install "convergio-edu"
+  end
+
+  def caveats
+    <<~EOS
+      Convergio Education has been installed!
+
+      To get started, run:
+        convergio-edu setup
+
+      This will configure your Azure OpenAI API key (GDPR-compliant).
+
+      Features:
+        - 17 AI Maestri teachers (Math, Physics, History, etc.)
+        - Socratic teaching methodology
+        - Age-appropriate content (6-19 years)
+        - GDPR-compliant (Azure OpenAI only)
+
+      Quick start:
+        convergio-edu              # Start interactive session
+        convergio-edu --help       # Show all options
+
+      Documentation: https://github.com/Roberdan/convergio-cli
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/convergio-edu --version")
+  end
+end

--- a/Formula/convergio.rb
+++ b/Formula/convergio.rb
@@ -1,13 +1,13 @@
 class Convergio < Formula
   desc "Multi-agent AI orchestration CLI for Apple Silicon"
   homepage "https://github.com/Roberdan/convergio-cli"
-  version "6.0.0"
+  version "6.0.2"
   license "MIT"
 
   on_macos do
     on_arm do
-      url "https://github.com/Roberdan/convergio-cli/releases/download/v6.0.0/convergio-6.0.0-arm64-apple-darwin.tar.gz"
-      sha256 "24995873794356027154c53048be562cf0e06161475c1e6914e5a6ff3573e8b1"
+      url "https://github.com/Roberdan/convergio-cli/releases/download/v6.0.2/convergio-6.0.2-arm64-apple-darwin.tar.gz"
+      sha256 "392341d26046e6dfaae37688dceeeb80246dd7e455abc713ea6bb2141dde556e"
     end
   end
 
@@ -26,11 +26,22 @@ class Convergio < Formula
     # Symlink notification helper to /Applications for system-wide access
     notify_app = prefix/"ConvergioNotify.app"
     if notify_app.exist?
-      target = Pathname.new("/Applications/ConvergioNotify.app")
-      target.rmtree if target.exist?
-      FileUtils.cp_r(notify_app, target)
-      # Register with Launch Services
-      system "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister", "-f", target
+      begin
+        target = Pathname.new("/Applications/ConvergioNotify.app")
+        # Remove existing if present (may require permissions)
+        if target.exist?
+          FileUtils.rm_rf(target) rescue nil
+        end
+        # Copy to /Applications
+        FileUtils.cp_r(notify_app, target) rescue nil
+        # Register with Launch Services if copy succeeded
+        if target.exist?
+          system "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister", "-f", target
+        end
+      rescue => e
+        opoo "Could not install ConvergioNotify.app to /Applications: #{e.message}"
+        opoo "You can manually copy it from #{notify_app}"
+      end
     end
   end
 

--- a/README.md
+++ b/README.md
@@ -679,8 +679,11 @@ Compare responses from multiple models:
 # Add the tap (once)
 brew tap Roberdan/convergio-cli
 
-# Install Master Edition (default)
-brew install convergio
+# Install your preferred edition:
+brew install convergio          # Master Edition (60+ agents, full-featured)
+brew install convergio-edu      # Education Edition (17 Maestri teachers)
+brew install convergio-biz      # Business Edition (10 business agents)
+brew install convergio-dev      # Developer Edition (11 DevOps agents)
 ```
 
 ### Installation from GitHub Release
@@ -748,9 +751,9 @@ Convergio is available in multiple editions, each focused on specific use cases:
 | Edition | Agents | Target Audience | Installation |
 |---------|--------|-----------------|--------------|
 | **Master** | 60+ | Developers, power users | `brew install convergio` |
-| **Education** | 18 | Students, teachers | `brew install convergio-edu` |
-| **Business** | 10 | SMBs, sales teams | `--edition business` |
-| **Developer** | 10 | DevOps, tech leads | `--edition developer` |
+| **Education** | 17 | Students, teachers, schools | `brew install convergio-edu` |
+| **Business** | 10 | SMBs, sales teams | `brew install convergio-biz` |
+| **Developer** | 11 | DevOps, tech leads | `brew install convergio-dev` |
 
 ### Switching Editions at Runtime
 


### PR DESCRIPTION
## Summary
- Add `convergio-edu.rb` formula for Education edition (17 Maestri teachers)
- Add `convergio-biz.rb` formula for Business edition (10 business agents)
- Add `convergio-dev.rb` formula for Developer edition (11 DevOps agents)
- Fix post_install error with proper error handling (ConvergioNotify.app copy failure)
- Update release workflow to push all 4 formulas to homebrew tap
- Update README with brew install instructions for all editions

## Installation Commands (after release)
```bash
brew tap Roberdan/convergio-cli
brew install convergio      # Master (60+ agents)
brew install convergio-edu  # Education (17 Maestri teachers)
brew install convergio-biz  # Business (10 business agents)
brew install convergio-dev  # Developer (11 DevOps agents)
```

## Test plan
- [x] Formula syntax is valid Ruby
- [x] SHA256 checksums match v6.0.2 release
- [x] post_install has proper error handling
- [x] Release workflow updates all 4 formulas
- [ ] Test brew install after v6.0.3 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)