### PR TITLE
docs: Update README and Homebrew formulas for v6.1.0

### DIFF
--- a/Formula/convergio-biz.rb
+++ b/Formula/convergio-biz.rb
@@ -1,13 +1,13 @@
 class ConvergioBiz < Formula
   desc "Convergio Business Edition - AI agents for sales, marketing & strategy"
   homepage "https://github.com/Roberdan/convergio-cli"
-  version "6.0.2"
+  version "6.1.0"
   license "MIT"
 
   on_macos do
     on_arm do
-      url "https://github.com/Roberdan/convergio-cli/releases/download/v6.0.2/convergio-biz-6.0.2-arm64-apple-darwin.tar.gz"
-      sha256 "b115ef3fce15013a14bab0627b6e37e3814d83199345f837a6923ed17bad7abb"
+      url "https://github.com/Roberdan/convergio-cli/releases/download/v6.1.0/convergio-biz-6.1.0-arm64-apple-darwin.tar.gz"
+      sha256 "422280c854038b00e760bb3bcd00245de799a78bba1ebcc36c0dbc1171e9fe6b"
     end
   end
 

--- a/Formula/convergio-dev.rb
+++ b/Formula/convergio-dev.rb
@@ -1,13 +1,13 @@
 class ConvergioDev < Formula
   desc "Convergio Developer Edition - AI agents for code review, DevOps & security"
   homepage "https://github.com/Roberdan/convergio-cli"
-  version "6.0.2"
+  version "6.1.0"
   license "MIT"
 
   on_macos do
     on_arm do
-      url "https://github.com/Roberdan/convergio-cli/releases/download/v6.0.2/convergio-dev-6.0.2-arm64-apple-darwin.tar.gz"
-      sha256 "76e45bb7725fe663be594c06f18080ac0e4da429ace697653b804a3976d4a84b"
+      url "https://github.com/Roberdan/convergio-cli/releases/download/v6.1.0/convergio-dev-6.1.0-arm64-apple-darwin.tar.gz"
+      sha256 "c81d4adcf6e1db205e6fd2f5037b71d384d812d114fc6188db4ff56f7f6e6e3a"
     end
   end
 

--- a/Formula/convergio-edu.rb
+++ b/Formula/convergio-edu.rb
@@ -1,13 +1,13 @@
 class ConvergioEdu < Formula
   desc "Convergio Education Edition - AI Maestri teachers for K-12 students"
   homepage "https://github.com/Roberdan/convergio-cli"
-  version "6.0.2"
+  version "6.1.0"
   license "MIT"
 
   on_macos do
     on_arm do
-      url "https://github.com/Roberdan/convergio-cli/releases/download/v6.0.2/convergio-edu-6.0.2-arm64-apple-darwin.tar.gz"
-      sha256 "d820d4da87486e09de840261835e81df3ae840383acab460163e6ee7ad743b99"
+      url "https://github.com/Roberdan/convergio-cli/releases/download/v6.1.0/convergio-edu-6.1.0-arm64-apple-darwin.tar.gz"
+      sha256 "ece2047492036e0aa9a8f4642eb5c8a1ffc999efd383cf6e79037fd7ca5781c4"
     end
   end
 

--- a/Formula/convergio.rb
+++ b/Formula/convergio.rb
@@ -1,13 +1,13 @@
 class Convergio < Formula
   desc "Multi-agent AI orchestration CLI for Apple Silicon"
   homepage "https://github.com/Roberdan/convergio-cli"
-  version "6.0.2"
+  version "6.1.0"
   license "MIT"
 
   on_macos do
     on_arm do
-      url "https://github.com/Roberdan/convergio-cli/releases/download/v6.0.2/convergio-6.0.2-arm64-apple-darwin.tar.gz"
-      sha256 "392341d26046e6dfaae37688dceeeb80246dd7e455abc713ea6bb2141dde556e"
+      url "https://github.com/Roberdan/convergio-cli/releases/download/v6.1.0/convergio-6.1.0-arm64-apple-darwin.tar.gz"
+      sha256 "8e63ddc39be98b15643dd9b149e591611add48748eed74712cff37997790350f"
     end
   end
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://github.com/Roberdan/convergio-cli/actions/workflows/ci.yml"><img src="https://github.com/Roberdan/convergio-cli/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://github.com/Roberdan/convergio-cli/releases/latest"><img src="https://img.shields.io/badge/version-6.0.2-blue" alt="Version 6.0.2"></a>
+  <a href="https://github.com/Roberdan/convergio-cli/releases/latest"><img src="https://img.shields.io/badge/version-6.1.0-blue" alt="Version 6.1.0"></a>
   <a href="https://github.com/Roberdan/convergio-cli/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"></a>
   <a href="https://github.com/Roberdan/convergio-cli"><img src="https://img.shields.io/badge/platform-macOS%20(Apple%20Silicon)-black" alt="Platform"></a>
   <a href="https://github.com/Roberdan/convergio-cli/stargazers"><img src="https://img.shields.io/github/stars/Roberdan/convergio-cli?style=social" alt="Stars"></a>
@@ -692,15 +692,15 @@ Download pre-built binaries for your edition:
 
 | Edition | Download | Description |
 |---------|----------|-------------|
-| **Master** | [convergio-6.0.2-arm64-apple-darwin.tar.gz](https://github.com/Roberdan/convergio-cli/releases/download/v6.0.2/convergio-6.0.2-arm64-apple-darwin.tar.gz) | Full-featured for power users |
-| **Education** | [convergio-edu-6.0.2-arm64-apple-darwin.tar.gz](https://github.com/Roberdan/convergio-cli/releases/download/v6.0.2/convergio-edu-6.0.2-arm64-apple-darwin.tar.gz) | Schools, students (Scuola 2026) |
-| **Business** | [convergio-biz-6.0.2-arm64-apple-darwin.tar.gz](https://github.com/Roberdan/convergio-cli/releases/download/v6.0.2/convergio-biz-6.0.2-arm64-apple-darwin.tar.gz) | Enterprise features |
-| **Developer** | [convergio-dev-6.0.2-arm64-apple-darwin.tar.gz](https://github.com/Roberdan/convergio-cli/releases/download/v6.0.2/convergio-dev-6.0.2-arm64-apple-darwin.tar.gz) | Debug tools, APIs |
+| **Master** | [convergio-6.1.0-arm64-apple-darwin.tar.gz](https://github.com/Roberdan/convergio-cli/releases/download/v6.1.0/convergio-6.1.0-arm64-apple-darwin.tar.gz) | Full-featured for power users |
+| **Education** | [convergio-edu-6.1.0-arm64-apple-darwin.tar.gz](https://github.com/Roberdan/convergio-cli/releases/download/v6.1.0/convergio-edu-6.1.0-arm64-apple-darwin.tar.gz) | Schools, students (Scuola 2026) |
+| **Business** | [convergio-biz-6.1.0-arm64-apple-darwin.tar.gz](https://github.com/Roberdan/convergio-cli/releases/download/v6.1.0/convergio-biz-6.1.0-arm64-apple-darwin.tar.gz) | Enterprise features |
+| **Developer** | [convergio-dev-6.1.0-arm64-apple-darwin.tar.gz](https://github.com/Roberdan/convergio-cli/releases/download/v6.1.0/convergio-dev-6.1.0-arm64-apple-darwin.tar.gz) | Debug tools, APIs |
 
 ```bash
 # Example: Install Education Edition manually
-curl -LO https://github.com/Roberdan/convergio-cli/releases/download/v6.0.2/convergio-edu-6.0.2-arm64-apple-darwin.tar.gz
-tar -xzf convergio-edu-6.0.2-arm64-apple-darwin.tar.gz
+curl -LO https://github.com/Roberdan/convergio-cli/releases/download/v6.1.0/convergio-edu-6.1.0-arm64-apple-darwin.tar.gz
+tar -xzf convergio-edu-6.1.0-arm64-apple-darwin.tar.gz
 sudo mv convergio-edu /usr/local/bin/
 
 # Run
@@ -1243,7 +1243,7 @@ MIT License - see [LICENSE](LICENSE) for details.
 ---
 
 <p align="center">
-  <strong>Convergio CLI v6.0.2</strong><br/>
+  <strong>Convergio CLI v6.1.0</strong><br/>
   <em>Multi-Model AI Orchestration for Apple Silicon</em>
 </p>
 


### PR DESCRIPTION
## Summary

- Update version badge to 6.1.0
- Update download links to v6.1.0 binaries  
- Update Homebrew formulas with new SHA256 hashes for all 4 editions

## Homebrew Installation

```bash
brew tap Roberdan/convergio-cli
brew install convergio          # Master (60+ agents)
brew install convergio-edu      # Education (17 Maestri)
brew install convergio-biz      # Business (10 agents)
brew install convergio-dev      # Developer (11 agents)
```

## Test Plan

- [ ] Verify badge shows 6.1.0
- [ ] Verify download links work
- [ ] Verify `brew install convergio` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)