### PR TITLE
fix: Update Homebrew formulas with v6.4.0 sha256

### DIFF
--- a/Formula/convergio-biz.rb
+++ b/Formula/convergio-biz.rb
@@ -7,8 +7,7 @@ class ConvergioBiz < Formula
   on_macos do
     on_arm do
       url "https://github.com/Roberdan/convergio-cli/releases/download/v6.4.0/convergio-biz-6.4.0-arm64-apple-darwin.tar.gz"
-      # sha256 will be updated after release tarball is created
-      sha256 "PLACEHOLDER_UPDATE_AFTER_RELEASE"
+      sha256 "3d2f9871308ffffb89323c14096dd9e8a26b79e268c4ee2fc3dfd99062f51cfc"
     end
   end
 

--- a/Formula/convergio-dev.rb
+++ b/Formula/convergio-dev.rb
@@ -7,8 +7,7 @@ class ConvergioDev < Formula
   on_macos do
     on_arm do
       url "https://github.com/Roberdan/convergio-cli/releases/download/v6.4.0/convergio-dev-6.4.0-arm64-apple-darwin.tar.gz"
-      # sha256 will be updated after release tarball is created
-      sha256 "PLACEHOLDER_UPDATE_AFTER_RELEASE"
+      sha256 "10d9a8f764edd11df761e447e1353c0ad036314b0b7e61a02ef885d7fc87ee6d"
     end
   end
 

--- a/Formula/convergio-edu.rb
+++ b/Formula/convergio-edu.rb
@@ -7,8 +7,7 @@ class ConvergioEdu < Formula
   on_macos do
     on_arm do
       url "https://github.com/Roberdan/convergio-cli/releases/download/v6.4.0/convergio-edu-6.4.0-arm64-apple-darwin.tar.gz"
-      # sha256 will be updated after release tarball is created
-      sha256 "PLACEHOLDER_UPDATE_AFTER_RELEASE"
+      sha256 "8c13e2a3d572836fba7f784a7c622f46dc83e506f4420b252379747cf1f66aac"
     end
   end
 

--- a/Formula/convergio.rb
+++ b/Formula/convergio.rb
@@ -7,8 +7,7 @@ class Convergio < Formula
   on_macos do
     on_arm do
       url "https://github.com/Roberdan/convergio-cli/releases/download/v6.4.0/convergio-6.4.0-arm64-apple-darwin.tar.gz"
-      # sha256 will be updated after release tarball is created
-      sha256 "PLACEHOLDER_UPDATE_AFTER_RELEASE"
+      sha256 "b623688be2adffcb742b0a523dc13862731ffca0e334783ae3562a69d65858ff"
     end
   end
 


### PR DESCRIPTION
## Summary
Updates all Homebrew formulas with correct sha256 checksums for v6.4.0 release.

## Checksums
| Formula | SHA256 |
|---------|--------|
| convergio.rb | `b623688be2adffcb742b0a523dc13862731ffca0e334783ae3562a69d65858ff` |
| convergio-edu.rb | `8c13e2a3d572836fba7f784a7c622f46dc83e506f4420b252379747cf1f66aac` |
| convergio-biz.rb | `3d2f9871308ffffb89323c14096dd9e8a26b79e268c4ee2fc3dfd99062f51cfc` |
| convergio-dev.rb | `10d9a8f764edd11df761e447e1353c0ad036314b0b7e61a02ef885d7fc87ee6d` |

## Test
After merge, all editions can be installed via:
```bash
brew tap Roberdan/convergio
brew install convergio      # or convergio-edu, convergio-biz, convergio-dev
```

🤖 Generated with the help of an AI team